### PR TITLE
Hexens Audit: Non-uniform Distribution in Random Nonce Generation Due to JavaScript Number Precision Limitations

### DIFF
--- a/src/jub/jub.ts
+++ b/src/jub/jub.ts
@@ -11,8 +11,10 @@ import {
 	poseidonDecrypt,
 	poseidonEncrypt,
 } from "maci-crypto";
+import { randomBytes } from "crypto";
 
 const BASE_POINT_ORDER = 2736030358979909402780800718157159386076813972158567259200215660948447373041n;
+
 
 // el-gamal decryption
 export const decryptPoint = (
@@ -57,9 +59,10 @@ export const encryptMessage = (
 	};
 };
 
-// generate a random bigint between 1 and 2^128
-export const randomNonce = (): bigint =>
-	BigInt(Math.floor(Math.random() * Number(2n ** 128n - 1n)) + 1);
+export const randomNonce = (): bigint => {
+	const bytes = randomBytes(16);
+	return BigInt("0x" + bytes.toString("hex")) + 1n;
+};
 
 export const processPoseidonEncryption = (
 	inputs: bigint[],


### PR DESCRIPTION
"The {{randomNonce()}} function in {{jub/jub.ts}} uses {{Math.random()}} and {{Number()}} type conversion to generate random nonces, which can lead to non-uniform distribution of values due to JavaScript's number precision limitations.


This implementation has two issues:

* {{Math.random()}} is not cryptographically secure
* Converting large BigInt values to Number type leads to precision loss beyond {{Number.MAX_SAFE_INTEGER}} (2^53 - 1)

{noformat}console.log(""Number.MAX_SAFE_INTEGER:"", Number.MAX_SAFE_INTEGER); // 9007199254740991
console.log(""2n ** 53n:"", 2n ** 53n);                            // 9007199254740992
console.log(Number(2n ** 53n) + 1);                              // 9007199254740992
console.log(Number(2n ** 53n) + 2);                              // 9007199254740994
console.log(Number(2n ** 53n) + 3);                              // 9007199254740996
console.log(Number(2n ** 53n) + 4);                              // 9007199254740996{noformat}

As shown above, numbers beyond {{MAX_SAFE_INTEGER}} lose precision, causing some values to be unreachable and others to be over-represented in the random distribution."