### PR TITLE
Hexens Audit: Redundant parameter in withdraw function

### DIFF
--- a/contracts/EncryptedERC.sol
+++ b/contracts/EncryptedERC.sol
@@ -531,7 +531,6 @@ contract EncryptedERC is TokenTracker, EncryptedUserBalances {
     }
 
     /**
-     * @param _amount Amount to withdraw
      * @param _tokenId Token ID
      * @param proof Proof
      * @param input Public inputs for the proof
@@ -540,13 +539,13 @@ contract EncryptedERC is TokenTracker, EncryptedUserBalances {
      * @dev Withdraws the encrypted amount to the ERC20 token
      */
     function withdraw(
-        uint256 _amount,
         uint256 _tokenId,
         uint256[8] calldata proof,
         uint256[16] calldata input,
         uint256[7] memory _balancePCT
     ) public {
         address from = msg.sender;
+        uint256 _amount = input[15];
 
         // revert if contract is not a converter
         if (!isConverter) {
@@ -557,13 +556,6 @@ contract EncryptedERC is TokenTracker, EncryptedUserBalances {
             // public key should match
             uint256[2] memory publicKey = registrar.getUserPublicKey(from);
             if (publicKey[0] != input[0] || publicKey[1] != input[1]) {
-                revert InvalidProof();
-            }
-        }
-
-        {
-            // _amount should match with the amount in the proof
-            if (_amount != input[15]) {
                 revert InvalidProof();
             }
         }

--- a/test/EncryptedERC-Converter.ts
+++ b/test/EncryptedERC-Converter.ts
@@ -3,9 +3,9 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import type { Registrar } from "../typechain-types/contracts/Registrar";
 import {
-	EncryptedERC__factory,
-	Registrar__factory,
-	SimpleERC20__factory,
+  EncryptedERC__factory,
+  Registrar__factory,
+  SimpleERC20__factory,
 } from "../typechain-types/factories/contracts";
 
 import { formatPrivKeyForBabyJub } from "maci-crypto";
@@ -13,1035 +13,968 @@ import { processPoseidonEncryption } from "../src/jub/jub";
 import type { EncryptedERC } from "../typechain-types/contracts/EncryptedERC";
 import type { SimpleERC20 } from "../typechain-types/contracts/SimpleERC20";
 import {
-	deployLibrary,
-	deployVerifiers,
-	generateGnarkProof,
-	getDecryptedBalance,
-	privateTransfer,
-	withdraw,
+  deployLibrary,
+  deployVerifiers,
+  generateGnarkProof,
+  getDecryptedBalance,
+  privateTransfer,
+  withdraw,
 } from "./helpers";
 import { User } from "./user";
 
 const DECIMALS = 10;
 
 describe("EncryptedERC - Converter", () => {
-	let registrar: Registrar;
-	let users: User[];
-	let signers: SignerWithAddress[];
-	let owner: SignerWithAddress;
-	let encryptedERC: EncryptedERC;
-	let blacklistedERC20: SimpleERC20;
-	const erc20s: SimpleERC20[] = [];
-
-	const deployFixture = async () => {
-		signers = await ethers.getSigners();
-		owner = signers[0];
-
-		const {
-			registrationVerifier,
-			mintVerifier,
-			withdrawVerifier,
-			transferVerifier,
-		} = await deployVerifiers(owner);
-		const babyJubJub = await deployLibrary(owner);
-
-		for (const d of [6, 18, DECIMALS]) {
-			const simpleERC20Factory = new SimpleERC20__factory(owner);
-			const simpleERC20_ = await simpleERC20Factory
-				.connect(owner)
-				.deploy("Test", "TEST", d);
-			await simpleERC20_.waitForDeployment();
-			erc20s.push(simpleERC20_);
-		}
-
-		const blacklistedERC20Factory = new SimpleERC20__factory(owner);
-		const blacklistedERC20_ = await blacklistedERC20Factory
-			.connect(owner)
-			.deploy("Blacklisted", "BL", 18);
-		await blacklistedERC20_.waitForDeployment();
-		blacklistedERC20 = blacklistedERC20_;
-
-		const registrarFactory = new Registrar__factory(owner);
-		const registrar_ = await registrarFactory
-			.connect(owner)
-			.deploy(registrationVerifier);
-
-		await registrar_.waitForDeployment();
-
-		const encryptedERCFactory = new EncryptedERC__factory({
-			"contracts/libraries/BabyJubJub.sol:BabyJubJub": babyJubJub,
-		});
-		const encryptedERC_ = await encryptedERCFactory.connect(owner).deploy({
-			_registrar: registrar_.target,
-			_isConverter: true,
-			_name: "Test",
-			_symbol: "TEST",
-			_mintVerifier: mintVerifier,
-			_withdrawVerifier: withdrawVerifier,
-			_transferVerifier: transferVerifier,
-			_decimals: DECIMALS,
-		});
-
-		await encryptedERC_.waitForDeployment();
-
-		registrar = registrar_;
-		encryptedERC = encryptedERC_;
-		users = signers.map((signer) => new User(signer));
-	};
-
-	before(async () => await deployFixture());
-
-	describe("Registrar", () => {
-		it("should deploy registrar properly", async () => {
-			expect(registrar.target).to.not.be.null;
-			expect(registrar).to.not.be.null;
-		});
-
-		it("should initialize properly", async () => {
-			const burnUserAddress = await registrar.BURN_USER();
-			const burnUserPublicKey = await registrar.userPublicKeys(burnUserAddress);
-			expect(burnUserPublicKey).to.deep.equal([0n, 1n]);
-		});
-
-		describe("Registration", () => {
-			it("users should be able to register properly", async () => {
-				// in register circuit we have 3 inputs
-				// private inputs = [senderPrivKey]
-				// public inputs = [senderPubKey[0], senderPubKey[1]]
-				for (const user of users.slice(0, 5)) {
-					const privateInputs = [
-						formatPrivKeyForBabyJub(user.privateKey).toString(),
-					];
-					const publicInputs = user.publicKey.map(String);
-					const input = {
-						privateInputs,
-						publicInputs,
-					};
-
-					const proof = await generateGnarkProof(
-						"REGISTER",
-						JSON.stringify(input),
-					);
-
-					const tx = await registrar
-						.connect(user.signer)
-						.register(
-							proof.map(BigInt),
-							publicInputs.map(BigInt) as [bigint, bigint],
-						);
-					await tx.wait();
-
-					// check if the user is registered
-					expect(await registrar.isUserRegistered(user.signer.address)).to.be
-						.true;
-
-					// and the public key is set
-					const publicKey = await registrar.getUserPublicKey(
-						user.signer.address,
-					);
-
-					expect(publicKey).to.deep.equal(user.publicKey);
-				}
-			});
-		});
-	});
-
-	describe("EncryptedERC", () => {
-		let auditorPublicKey: [bigint, bigint];
-
-		it("should initialize properly", async () => {
-			expect(encryptedERC.target).to.not.be.null;
-			expect(encryptedERC).to.not.be.null;
-
-			// since eerc is standalone name and symbol should not be set
-			expect(await encryptedERC.name()).to.equal("");
-			expect(await encryptedERC.symbol()).to.equal("");
-
-			// auditor key should not be set
-			expect(await encryptedERC.isAuditorKeySet()).to.be.false;
-		});
-
-		it("should revert if auditor key is not set", async () => {
-			await expect(
-				encryptedERC.connect(users[0].signer).privateMint(
-					users[0].signer.address,
-					Array.from({ length: 8 }, () => 1n),
-					Array.from({ length: 22 }, () => 1n),
-				),
-			).to.be.reverted;
-		});
-
-		it("should revert if user try to private mint", async () => {
-			await expect(
-				encryptedERC.connect(users[0].signer).privateMint(
-					users[0].signer.address,
-					Array.from({ length: 8 }, () => 1n),
-					Array.from({ length: 22 }, () => 1n),
-				),
-			).to.be.reverted;
-		});
-
-		describe("Auditor Key Set", () => {
-			it("can not deposit if auditor key is not set", async () => {
-				await expect(
-					encryptedERC.connect(users[0].signer).deposit(
-						1n,
-						erc20s[0].target,
-						Array.from({ length: 7 }, () => 1n),
-					),
-				).to.be.reverted;
-			});
-
-			it("only owner can set auditor key", async () => {
-				await expect(
-					encryptedERC
-						.connect(users[4].signer)
-						.setAuditorPublicKey(users[0].signer.address),
-				).to.be.reverted;
-			});
-
-			it("owner can set auditor key", async () => {
-				const tx = await encryptedERC
-					.connect(owner)
-					.setAuditorPublicKey(owner.address);
-				await tx.wait();
-
-				expect(await encryptedERC.isAuditorKeySet()).to.be.true;
-			});
-
-			it("auditor and auditor key should be set", async () => {
-				const auditor = await encryptedERC.auditor();
-				const auditorKey = await encryptedERC.auditorPublicKey();
-
-				expect(auditor).to.equal(users[0].signer.address);
-				expect(auditorKey).to.deep.equal([
-					users[0].publicKey[0],
-					users[0].publicKey[1],
-				]);
-
-				auditorPublicKey = [users[0].publicKey[0], users[0].publicKey[1]];
-			});
-
-			it("should revert if user try to private burn in converter", async () => {
-				await expect(
-					encryptedERC.connect(users[0].signer).privateBurn(
-						Array.from({ length: 8 }, () => 1n),
-						Array.from({ length: 32 }, () => 1n),
-						Array.from({ length: 7 }, () => 1n),
-					),
-				).to.be.revertedWithCustomError(encryptedERC, "InvalidOperation");
-			});
-		});
-
-		describe("Depositing Tokens - Higher ERC20 Decimals (18)", () => {
-			const mintAmount = 1000000000000000000000000000n;
-			let userEncryptedBalance = 0n;
-
-			it("should initialize user balance to 0", async () => {
-				const ownerUser = users[0];
-				const balance = await encryptedERC.balanceOf(
-					ownerUser.signer.address,
-					1,
-				);
-
-				const totalBalance = await getDecryptedBalance(
-					ownerUser.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				userEncryptedBalance = totalBalance;
-			});
-
-			it("mint some tokens to the owner", async () => {
-				const erc20 = erc20s[1];
-				const tx = await erc20.connect(owner).mint(owner.address, mintAmount);
-				await tx.wait();
-
-				const balance = await erc20.balanceOf(owner.address);
-				expect(balance).to.equal(mintAmount);
-			});
-
-			it("should deposit tokens to EncryptedERC and return the dust properly and mint the proper balance", async () => {
-				const ownerUser = users[0];
-				const erc20 = erc20s[1];
-
-				const cases = [
-					{
-						convertedAmount: 1_005_000_000_000_000_000_000n,
-						dust: 0n,
-						encryptedValue: 10_050_000_000_000n,
-					},
-					{
-						convertedAmount: 1_000_000_000_000_000_000_000n,
-						dust: 0n,
-						encryptedValue: 10_000_000_000_000n,
-					},
-					{
-						convertedAmount: 1_000_000_001n,
-						dust: 1n,
-						encryptedValue: 10n,
-					},
-					{
-						convertedAmount: 1_000_000_001_000_000_000n,
-						dust: 0n,
-						encryptedValue: 10_000_000_010n,
-					},
-					{
-						convertedAmount: 100_000_000n,
-						dust: 0n,
-						encryptedValue: 1n,
-					},
-					{
-						convertedAmount: 50_000_000n,
-						dust: 50_000_000n,
-						encryptedValue: 0n,
-					},
-					{
-						convertedAmount: 1_234_567_890n,
-						dust: 34_567_890n,
-						encryptedValue: 12n,
-					},
-				];
-
-				for (const testCase of cases) {
-					// approve the deposit
-					await erc20
-						.connect(owner)
-						.approve(encryptedERC.target, testCase.convertedAmount);
-
-					const erc20BalanceBefore = await erc20.balanceOf(owner.address);
-
-					// need to create a new pct for the amount
-					const { ciphertext, nonce, authKey } = processPoseidonEncryption(
-						[testCase.encryptedValue],
-						ownerUser.publicKey,
-					);
-
-					await encryptedERC
-						.connect(owner)
-						.deposit(testCase.convertedAmount, erc20.target, [
-							...ciphertext,
-							...authKey,
-							nonce,
-						]);
-
-					const erc20BalanceAfter = await erc20.balanceOf(owner.address);
-					expect(erc20BalanceAfter).to.equal(
-						erc20BalanceBefore - testCase.convertedAmount + testCase.dust,
-					);
-
-					const balance = await encryptedERC.balanceOf(
-						ownerUser.signer.address,
-						1,
-					);
-
-					const totalBalance = await getDecryptedBalance(
-						ownerUser.privateKey,
-						balance.amountPCTs,
-						balance.balancePCT,
-						balance.eGCT,
-					);
-
-					expect(totalBalance).to.equal(
-						userEncryptedBalance + testCase.encryptedValue,
-					);
-					userEncryptedBalance = totalBalance;
-				}
-			});
-
-			// this test should be here because it needs the encryptedERC to be initialized and deposit to be done
-			it("get tokens should return the proper addresses", async () => {
-				const contractTokens = await encryptedERC.getTokens();
-				expect(contractTokens).to.deep.equal([erc20s[1].target]);
-			});
-
-			it("should revert if user is not registered", async () => {
-				await expect(
-					encryptedERC.connect(users[5].signer).deposit(
-						1n,
-						users[0].signer.address,
-						Array.from({ length: 7 }, () => 1n),
-					),
-				).to.be.reverted;
-			});
-		});
-
-		describe("Depositing Tokens - Lower ERC20 Decimals (6)", () => {
-			const mintAmount = 1000000000000000000000000n;
-			let userEncryptedBalance = 0n;
-
-			it("mint some tokens to the owner", async () => {
-				const erc20 = erc20s[0];
-
-				const tx = await erc20.connect(owner).mint(owner.address, mintAmount);
-				await tx.wait();
-
-				const balance = await erc20.balanceOf(owner.address);
-				expect(balance).to.equal(mintAmount);
-			});
-
-			it("should initialize user balance to 0", async () => {
-				const ownerUser = users[0];
-				const balance = await encryptedERC.getBalanceFromTokenAddress(
-					ownerUser.signer.address,
-					erc20s[0].target,
-				);
-
-				const totalBalance = await getDecryptedBalance(
-					ownerUser.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-				userEncryptedBalance = totalBalance;
-			});
-
-			it("should deposit tokens to EncryptedERC and return the dust properly and mint the proper balance", async () => {
-				const ownerUser = users[0];
-
-				const cases = [
-					{
-						convertedAmount: 1_000_000n,
-						dust: 0n,
-						encryptedValue: 10_000_000_000n,
-					},
-					{
-						convertedAmount: 1_000_001n,
-						dust: 0n,
-						encryptedValue: 10_000_010_000n,
-					},
-					{
-						convertedAmount: 500_000n,
-						dust: 0n,
-						encryptedValue: 5_000_000_000n,
-					},
-					{
-						convertedAmount: 123_456_789n,
-						dust: 0n,
-						encryptedValue: 1_234_567_890_000n,
-					},
-				];
-
-				const erc20 = erc20s[0];
-
-				for (const testCase of cases) {
-					// approve the deposit
-					await erc20
-						.connect(owner)
-						.approve(encryptedERC.target, testCase.convertedAmount);
-
-					const erc20BalanceBefore = await erc20.balanceOf(owner.address);
-
-					// need to create a new pct for the amount pct
-					const { ciphertext, nonce, authKey } = processPoseidonEncryption(
-						[testCase.encryptedValue],
-						ownerUser.publicKey,
-					);
-
-					await encryptedERC
-						.connect(owner)
-						.deposit(testCase.convertedAmount, erc20.target, [
-							...ciphertext,
-							...authKey,
-							nonce,
-						]);
-
-					const erc20BalanceAfter = await erc20.balanceOf(owner.address);
-					expect(erc20BalanceAfter).to.equal(
-						erc20BalanceBefore - testCase.convertedAmount + testCase.dust,
-					);
-
-					const balance = await encryptedERC.balanceOf(
-						ownerUser.signer.address,
-						2,
-					);
-
-					const totalBalance = await getDecryptedBalance(
-						ownerUser.privateKey,
-						balance.amountPCTs,
-						balance.balancePCT,
-						balance.eGCT,
-					);
-
-					expect(totalBalance).to.equal(
-						userEncryptedBalance + testCase.encryptedValue,
-					);
-					userEncryptedBalance = totalBalance;
-				}
-			});
-
-			it("get tokens should return the proper addresses", async () => {
-				const contractTokens = await encryptedERC.getTokens();
-				expect(contractTokens).to.deep.equal([
-					erc20s[1].target,
-					erc20s[0].target,
-				]);
-			});
-
-			it("should revert of user does not have enough token or enough approval for the deposit", async () => {
-				const user = users[1];
-
-				await expect(
-					encryptedERC.connect(user.signer).deposit(
-						1n,
-						erc20s[0].target,
-						Array.from({ length: 7 }, () => 1n),
-					),
-				).to.be.reverted;
-			});
-		});
-
-		describe("Depositing Tokens - Same ERC20 Decimals (10)", () => {
-			const mintAmount = 1000000000000000000000000n;
-			let userEncryptedBalance = 0n;
-
-			it("mint some tokens to the owner", async () => {
-				const erc20 = erc20s[2];
-
-				const tx = await erc20.connect(owner).mint(owner.address, mintAmount);
-				await tx.wait();
-
-				const balance = await erc20.balanceOf(owner.address);
-				expect(balance).to.equal(mintAmount);
-			});
-
-			it("should initialize user balance to 0", async () => {
-				const ownerUser = users[0];
-				const balance = await encryptedERC.balanceOf(
-					ownerUser.signer.address,
-					3,
-				);
-
-				const totalBalance = await getDecryptedBalance(
-					ownerUser.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-				userEncryptedBalance = totalBalance;
-			});
-
-			it("should deposit tokens to EncryptedERC and return the dust properly and mint the proper balance", async () => {
-				const ownerUser = users[0];
-
-				const cases = [
-					{
-						convertedAmount: 1_000_000_000n,
-						dust: 0n,
-						encryptedValue: 1_000_000_000n,
-					},
-					{
-						convertedAmount: 123_456_789_000n,
-						dust: 0n,
-						encryptedValue: 123_456_789_000n,
-					},
-					{
-						convertedAmount: 50_000_000_000n,
-						dust: 0n,
-						encryptedValue: 50_000_000_000n,
-					},
-					{
-						convertedAmount: 1_000n,
-						dust: 0n,
-						encryptedValue: 1_000n,
-					},
-					{
-						convertedAmount: 999_999_999_999n,
-						dust: 0n,
-						encryptedValue: 999_999_999_999n,
-					},
-				];
-
-				const erc20 = erc20s[2];
-
-				for (const testCase of cases) {
-					// approve the deposit
-					await erc20
-						.connect(owner)
-						.approve(encryptedERC.target, testCase.convertedAmount);
-
-					const erc20BalanceBefore = await erc20.balanceOf(owner.address);
-
-					// need to create a new pct for the amount pct
-					const { ciphertext, nonce, authKey } = processPoseidonEncryption(
-						[testCase.encryptedValue],
-						ownerUser.publicKey,
-					);
-
-					await encryptedERC
-						.connect(owner)
-						.deposit(testCase.convertedAmount, erc20.target, [
-							...ciphertext,
-							...authKey,
-							nonce,
-						]);
-
-					const erc20BalanceAfter = await erc20.balanceOf(owner.address);
-					expect(erc20BalanceAfter).to.equal(
-						erc20BalanceBefore - testCase.convertedAmount + testCase.dust,
-					);
-
-					const balance = await encryptedERC.balanceOf(
-						ownerUser.signer.address,
-						3,
-					);
-
-					const totalBalance = await getDecryptedBalance(
-						ownerUser.privateKey,
-						balance.amountPCTs,
-						balance.balancePCT,
-						balance.eGCT,
-					);
-
-					expect(totalBalance).to.equal(
-						userEncryptedBalance + testCase.encryptedValue,
-					);
-					userEncryptedBalance = totalBalance;
-				}
-			});
-
-			it("get tokens should return the proper addresses", async () => {
-				const contractTokens = await encryptedERC.getTokens();
-				expect(contractTokens).to.deep.equal([
-					erc20s[1].target,
-					erc20s[0].target,
-					erc20s[2].target,
-				]);
-			});
-		});
-
-		describe("Blacklisting Tokens", () => {
-			it("set token as blacklisted", async () => {
-
-				await encryptedERC.connect(owner).setTokenBlacklist(
-					blacklistedERC20.target,
-					true,
-				);
-
-				const isBlacklisted = await encryptedERC.isTokenBlacklisted(
-					blacklistedERC20.target,
-				);
-				expect(isBlacklisted).to.equal(true);
-			});
-
-			it("should revert if token is blacklisted", async () => {
-				const user = users[0];
-
-				await expect(
-					encryptedERC.connect(user.signer).deposit(
-						1n,
-						blacklistedERC20.target,
-						Array.from({ length: 7 }, () => 1n),
-					),
-				).to.be.reverted;
-			});
-		});
-
-		describe("Withdrawing Tokens - Lower ERC20 Decimals (6)", () => {
-			const tokenId = 2;
-			const withdrawAmount = 1000n;
-			let userInitialBalance: bigint;
-			let validProof: {
-				proof: string[];
-				publicInputs: string[];
-				userBalancePCT: string[];
-			};
-
-			it("should initialize user balance properly", async () => {
-				const user = users[0];
-
-				const balance = await encryptedERC.balanceOf(
-					user.signer.address,
-					tokenId,
-				);
-
-				const totalBalance = await getDecryptedBalance(
-					user.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				userInitialBalance = totalBalance;
-			});
-
-			it("should withdraw token properly", async () => {
-				const user = users[0];
-				const balance = await encryptedERC.balanceOf(
-					user.signer.address,
-					tokenId,
-				);
-				const userEncryptedBalance = [...balance.eGCT.c1, ...balance.eGCT.c2];
-
-				const { proof, publicInputs, userBalancePCT } = await withdraw(
-					withdrawAmount,
-					user,
-					userEncryptedBalance,
-					userInitialBalance,
-					auditorPublicKey,
-				);
-
-				expect(
-					await encryptedERC
-						.connect(user.signer)
-						.withdraw(
-							withdrawAmount,
-							tokenId,
-							proof,
-							publicInputs,
-							userBalancePCT,
-						),
-				).to.be.not.reverted;
-
-				validProof = { proof, publicInputs, userBalancePCT };
-			});
-
-			it("after withdrawing, the user balance should be updated properly", async () => {
-				const user = users[0];
-				const balance = await encryptedERC.balanceOf(
-					user.signer.address,
-					tokenId,
-				);
-
-				const totalBalance = await getDecryptedBalance(
-					user.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				expect(totalBalance).to.equal(userInitialBalance - withdrawAmount);
-			});
-
-			it("should revert if public keys are not matching", async () => {
-				const user = users[1];
-
-				await expect(
-					encryptedERC
-						.connect(user.signer)
-						.withdraw(
-							withdrawAmount,
-							tokenId,
-							validProof.proof,
-							validProof.publicInputs,
-							validProof.userBalancePCT,
-						),
-				).to.be.revertedWithCustomError(encryptedERC, "InvalidProof");
-			});
-
-			it("should revert if amount is not matching", async () => {
-				const user = users[0];
-
-				await expect(
-					encryptedERC
-						.connect(user.signer)
-						.withdraw(
-							withdrawAmount + 1n,
-							tokenId,
-							validProof.proof,
-							validProof.publicInputs,
-							validProof.userBalancePCT,
-						),
-				).to.be.revertedWithCustomError(encryptedERC, "InvalidProof");
-			});
-
-			it("should revert if auditor public key is not matching", async () => {
-				const _publicInputs = [...validProof.publicInputs];
-				_publicInputs[6] = "0";
-				_publicInputs[7] = "0";
-
-				await expect(
-					encryptedERC
-						.connect(users[0].signer)
-						.withdraw(
-							withdrawAmount,
-							tokenId,
-							validProof.proof,
-							_publicInputs,
-							validProof.userBalancePCT,
-						),
-				).to.be.revertedWithCustomError(encryptedERC, "InvalidProof");
-			});
-
-			it("should revert if proof is not valid", async () => {
-				const user = users[0];
-				const _proof = [...validProof.proof];
-				_proof[0] = "0";
-
-				await expect(
-					encryptedERC
-						.connect(user.signer)
-						.withdraw(
-							withdrawAmount,
-							tokenId,
-							validProof.proof,
-							validProof.publicInputs,
-							validProof.userBalancePCT,
-						),
-				).to.be.revertedWithCustomError(encryptedERC, "InvalidProof");
-			});
-
-			it("should revert if token is not registered", async () => {
-				const user = users[0];
-
-				await expect(
-					encryptedERC
-						.connect(user.signer)
-						.withdraw(
-							withdrawAmount,
-							10n,
-							validProof.proof,
-							validProof.publicInputs,
-							validProof.userBalancePCT,
-						),
-				).to.be.revertedWithCustomError(encryptedERC, "UnknownToken");
-			});
-		});
-
-		describe("Withdrawing Tokens - Higher ERC20 Decimals (10)", () => {
-			const tokenId = 1;
-			const withdrawAmount = 10000n;
-			let userInitialBalance: bigint;
-			let validProof: {
-				proof: string[];
-				publicInputs: string[];
-				userBalancePCT: string[];
-			};
-
-			it("should initialize user balance properly", async () => {
-				const user = users[0];
-				const balance = await encryptedERC.balanceOf(
-					user.signer.address,
-					tokenId,
-				);
-
-				const totalBalance = await getDecryptedBalance(
-					user.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				userInitialBalance = totalBalance;
-			});
-
-			it("should withdraw token properly", async () => {
-				const user = users[0];
-				const balance = await encryptedERC.balanceOf(
-					user.signer.address,
-					tokenId,
-				);
-				const userEncryptedBalance = [...balance.eGCT.c1, ...balance.eGCT.c2];
-
-				const { proof, publicInputs, userBalancePCT } = await withdraw(
-					withdrawAmount,
-					user,
-					userEncryptedBalance,
-					userInitialBalance,
-					auditorPublicKey,
-				);
-
-				expect(
-					await encryptedERC
-						.connect(user.signer)
-						.withdraw(
-							withdrawAmount,
-							tokenId,
-							proof,
-							publicInputs,
-							userBalancePCT,
-						),
-				).to.be.not.reverted;
-
-				validProof = { proof, publicInputs, userBalancePCT };
-			});
-
-			it("after withdrawing, the user balance should be updated properly", async () => {
-				const user = users[0];
-				const balance = await encryptedERC.balanceOf(
-					user.signer.address,
-					tokenId,
-				);
-
-				const totalBalance = await getDecryptedBalance(
-					user.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				expect(totalBalance).to.equal(userInitialBalance - withdrawAmount);
-			});
-		});
-
-		describe("Transferring Tokens - 1", () => {
-			let senderBalance: bigint; // hardcoded for now from the deposit test
-			const transferAmount = 1000n;
-
-			it("sender balance should initialized properly", async () => {
-				const sender = users[0];
-
-				const balance = await encryptedERC.balanceOf(sender.signer.address, 1);
-
-				const totalBalance = await getDecryptedBalance(
-					sender.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				senderBalance = totalBalance;
-			});
-
-			it("should transfer tokens properly", async () => {
-				const sender = users[0];
-				const receiver = users[1];
-
-				const balance = await encryptedERC.balanceOf(sender.signer.address, 1);
-				const senderEncryptedBalance = [...balance.eGCT.c1, ...balance.eGCT.c2];
-
-				const { proof, publicInputs, senderBalancePCT } = await privateTransfer(
-					sender,
-					senderBalance,
-					receiver.publicKey,
-					transferAmount,
-					senderEncryptedBalance,
-					auditorPublicKey,
-				);
-
-				expect(
-					await encryptedERC
-						.connect(sender.signer)
-						.transfer(
-							receiver.signer.address,
-							1n,
-							proof,
-							publicInputs,
-							senderBalancePCT,
-						),
-				).to.be.not.reverted;
-
-				senderBalance = senderBalance - transferAmount;
-			});
-
-			it("sender balance should be updated properly", async () => {
-				const sender = users[0];
-
-				const balance = await encryptedERC.balanceOf(sender.signer.address, 1);
-
-				const totalBalance = await getDecryptedBalance(
-					sender.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				expect(totalBalance).to.equal(senderBalance);
-			});
-
-			it("receiver balance should be updated properly", async () => {
-				const receiver = users[1];
-
-				const balance = await encryptedERC.balanceOf(
-					receiver.signer.address,
-					1,
-				);
-
-				const totalBalance = await getDecryptedBalance(
-					receiver.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				expect(totalBalance).to.equal(transferAmount);
-			});
-		});
-
-		describe("Transferring Tokens - 2", () => {
-			let senderBalance: bigint; // hardcoded for now from the deposit test
-			const transferAmount = 1000n;
-
-			it("sender balance should initialized properly", async () => {
-				const sender = users[0];
-
-				const balance = await encryptedERC.balanceOf(sender.signer.address, 2);
-
-				const totalBalance = await getDecryptedBalance(
-					sender.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				senderBalance = totalBalance;
-			});
-
-			it("should transfer tokens properly", async () => {
-				const sender = users[0];
-				const receiver = users[1];
-
-				const balance = await encryptedERC.balanceOf(sender.signer.address, 2);
-				const senderEncryptedBalance = [...balance.eGCT.c1, ...balance.eGCT.c2];
-
-				const { proof, publicInputs, senderBalancePCT } = await privateTransfer(
-					sender,
-					senderBalance,
-					receiver.publicKey,
-					transferAmount,
-					senderEncryptedBalance,
-					auditorPublicKey,
-				);
-
-				expect(
-					await encryptedERC
-						.connect(sender.signer)
-						.transfer(
-							receiver.signer.address,
-							2n,
-							proof,
-							publicInputs,
-							senderBalancePCT,
-						),
-				).to.be.not.reverted;
-
-				senderBalance = senderBalance - transferAmount;
-			});
-
-			it("sender balance should be updated properly", async () => {
-				const sender = users[0];
-
-				const balance = await encryptedERC.balanceOf(sender.signer.address, 2);
-
-				const totalBalance = await getDecryptedBalance(
-					sender.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				expect(totalBalance).to.equal(senderBalance);
-			});
-
-			it("receiver balance should be updated properly", async () => {
-				const receiver = users[1];
-
-				const balance = await encryptedERC.balanceOf(
-					receiver.signer.address,
-					2,
-				);
-
-				const totalBalance = await getDecryptedBalance(
-					receiver.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				expect(totalBalance).to.equal(transferAmount);
-			});
-		});
-	});
+  let registrar: Registrar;
+  let users: User[];
+  let signers: SignerWithAddress[];
+  let owner: SignerWithAddress;
+  let encryptedERC: EncryptedERC;
+  const erc20s: SimpleERC20[] = [];
+
+  const deployFixture = async () => {
+    signers = await ethers.getSigners();
+    owner = signers[0];
+
+    const {
+      registrationVerifier,
+      mintVerifier,
+      withdrawVerifier,
+      transferVerifier,
+    } = await deployVerifiers(owner);
+    const babyJubJub = await deployLibrary(owner);
+
+    for (const d of [6, 18, DECIMALS]) {
+      const simpleERC20Factory = new SimpleERC20__factory(owner);
+      const simpleERC20_ = await simpleERC20Factory
+        .connect(owner)
+        .deploy("Test", "TEST", d);
+      await simpleERC20_.waitForDeployment();
+      erc20s.push(simpleERC20_);
+    }
+
+    const registrarFactory = new Registrar__factory(owner);
+    const registrar_ = await registrarFactory
+      .connect(owner)
+      .deploy(registrationVerifier);
+
+    await registrar_.waitForDeployment();
+
+    const encryptedERCFactory = new EncryptedERC__factory({
+      "contracts/libraries/BabyJubJub.sol:BabyJubJub": babyJubJub,
+    });
+    const encryptedERC_ = await encryptedERCFactory.connect(owner).deploy({
+      _registrar: registrar_.target,
+      _isConverter: true,
+      _name: "Test",
+      _symbol: "TEST",
+      _mintVerifier: mintVerifier,
+      _withdrawVerifier: withdrawVerifier,
+      _transferVerifier: transferVerifier,
+      _decimals: DECIMALS,
+    });
+
+    await encryptedERC_.waitForDeployment();
+
+    registrar = registrar_;
+    encryptedERC = encryptedERC_;
+    users = signers.map((signer) => new User(signer));
+  };
+
+  before(async () => await deployFixture());
+
+  describe("Registrar", () => {
+    it("should deploy registrar properly", async () => {
+      expect(registrar.target).to.not.be.null;
+      expect(registrar).to.not.be.null;
+    });
+
+    it("should initialize properly", async () => {
+      const burnUserAddress = await registrar.BURN_USER();
+      const burnUserPublicKey = await registrar.userPublicKeys(burnUserAddress);
+      expect(burnUserPublicKey).to.deep.equal([0n, 1n]);
+    });
+
+    describe("Registration", () => {
+      it("users should be able to register properly", async () => {
+        // in register circuit we have 3 inputs
+        // private inputs = [senderPrivKey]
+        // public inputs = [senderPubKey[0], senderPubKey[1]]
+        for (const user of users.slice(0, 5)) {
+          const privateInputs = [
+            formatPrivKeyForBabyJub(user.privateKey).toString(),
+          ];
+          const publicInputs = user.publicKey.map(String);
+          const input = {
+            privateInputs,
+            publicInputs,
+          };
+
+          const proof = await generateGnarkProof(
+            "REGISTER",
+            JSON.stringify(input)
+          );
+
+          const tx = await registrar
+            .connect(user.signer)
+            .register(
+              proof.map(BigInt),
+              publicInputs.map(BigInt) as [bigint, bigint]
+            );
+          await tx.wait();
+
+          // check if the user is registered
+          expect(await registrar.isUserRegistered(user.signer.address)).to.be
+            .true;
+
+          // and the public key is set
+          const publicKey = await registrar.getUserPublicKey(
+            user.signer.address
+          );
+
+          expect(publicKey).to.deep.equal(user.publicKey);
+        }
+      });
+    });
+  });
+
+  describe("EncryptedERC", () => {
+    let auditorPublicKey: [bigint, bigint];
+
+    it("should initialize properly", async () => {
+      expect(encryptedERC.target).to.not.be.null;
+      expect(encryptedERC).to.not.be.null;
+
+      // since eerc is standalone name and symbol should not be set
+      expect(await encryptedERC.name()).to.equal("");
+      expect(await encryptedERC.symbol()).to.equal("");
+
+      // auditor key should not be set
+      expect(await encryptedERC.isAuditorKeySet()).to.be.false;
+    });
+
+    it("should revert if auditor key is not set", async () => {
+      await expect(
+        encryptedERC.connect(users[0].signer).privateMint(
+          users[0].signer.address,
+          Array.from({ length: 8 }, () => 1n),
+          Array.from({ length: 22 }, () => 1n)
+        )
+      ).to.be.reverted;
+    });
+
+    it("should revert if user try to private mint", async () => {
+      await expect(
+        encryptedERC.connect(users[0].signer).privateMint(
+          users[0].signer.address,
+          Array.from({ length: 8 }, () => 1n),
+          Array.from({ length: 22 }, () => 1n)
+        )
+      ).to.be.reverted;
+    });
+
+    describe("Auditor Key Set", () => {
+      it("can not deposit if auditor key is not set", async () => {
+        await expect(
+          encryptedERC.connect(users[0].signer).deposit(
+            1n,
+            erc20s[0].target,
+            Array.from({ length: 7 }, () => 1n)
+          )
+        ).to.be.reverted;
+      });
+
+      it("only owner can set auditor key", async () => {
+        await expect(
+          encryptedERC
+            .connect(users[4].signer)
+            .setAuditorPublicKey(users[0].signer.address)
+        ).to.be.reverted;
+      });
+
+      it("owner can set auditor key", async () => {
+        const tx = await encryptedERC
+          .connect(owner)
+          .setAuditorPublicKey(owner.address);
+        await tx.wait();
+
+        expect(await encryptedERC.isAuditorKeySet()).to.be.true;
+      });
+
+      it("auditor and auditor key should be set", async () => {
+        const auditor = await encryptedERC.auditor();
+        const auditorKey = await encryptedERC.auditorPublicKey();
+
+        expect(auditor).to.equal(users[0].signer.address);
+        expect(auditorKey).to.deep.equal([
+          users[0].publicKey[0],
+          users[0].publicKey[1],
+        ]);
+
+        auditorPublicKey = [users[0].publicKey[0], users[0].publicKey[1]];
+      });
+
+      it("should revert if user try to private burn in converter", async () => {
+        await expect(
+          encryptedERC.connect(users[0].signer).privateBurn(
+            Array.from({ length: 8 }, () => 1n),
+            Array.from({ length: 32 }, () => 1n),
+            Array.from({ length: 7 }, () => 1n)
+          )
+        ).to.be.revertedWithCustomError(encryptedERC, "InvalidOperation");
+      });
+    });
+
+    describe("Depositing Tokens - Higher ERC20 Decimals (18)", () => {
+      const mintAmount = 1000000000000000000000000000n;
+      let userEncryptedBalance = 0n;
+
+      it("should initialize user balance to 0", async () => {
+        const ownerUser = users[0];
+        const balance = await encryptedERC.balanceOf(
+          ownerUser.signer.address,
+          1
+        );
+
+        const totalBalance = await getDecryptedBalance(
+          ownerUser.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        userEncryptedBalance = totalBalance;
+      });
+
+      it("mint some tokens to the owner", async () => {
+        const erc20 = erc20s[1];
+        const tx = await erc20.connect(owner).mint(owner.address, mintAmount);
+        await tx.wait();
+
+        const balance = await erc20.balanceOf(owner.address);
+        expect(balance).to.equal(mintAmount);
+      });
+
+      it("should deposit tokens to EncryptedERC and return the dust properly and mint the proper balance", async () => {
+        const ownerUser = users[0];
+        const erc20 = erc20s[1];
+
+        const cases = [
+          {
+            convertedAmount: 1_005_000_000_000_000_000_000n,
+            dust: 0n,
+            encryptedValue: 10_050_000_000_000n,
+          },
+          {
+            convertedAmount: 1_000_000_000_000_000_000_000n,
+            dust: 0n,
+            encryptedValue: 10_000_000_000_000n,
+          },
+          {
+            convertedAmount: 1_000_000_001n,
+            dust: 1n,
+            encryptedValue: 10n,
+          },
+          {
+            convertedAmount: 1_000_000_001_000_000_000n,
+            dust: 0n,
+            encryptedValue: 10_000_000_010n,
+          },
+          {
+            convertedAmount: 100_000_000n,
+            dust: 0n,
+            encryptedValue: 1n,
+          },
+          {
+            convertedAmount: 50_000_000n,
+            dust: 50_000_000n,
+            encryptedValue: 0n,
+          },
+          {
+            convertedAmount: 1_234_567_890n,
+            dust: 34_567_890n,
+            encryptedValue: 12n,
+          },
+        ];
+
+        for (const testCase of cases) {
+          // approve the deposit
+          await erc20
+            .connect(owner)
+            .approve(encryptedERC.target, testCase.convertedAmount);
+
+          const erc20BalanceBefore = await erc20.balanceOf(owner.address);
+
+          // need to create a new pct for the amount
+          const { ciphertext, nonce, authKey } = processPoseidonEncryption(
+            [testCase.encryptedValue],
+            ownerUser.publicKey
+          );
+
+          await encryptedERC
+            .connect(owner)
+            .deposit(testCase.convertedAmount, erc20.target, [
+              ...ciphertext,
+              ...authKey,
+              nonce,
+            ]);
+
+          const erc20BalanceAfter = await erc20.balanceOf(owner.address);
+          expect(erc20BalanceAfter).to.equal(
+            erc20BalanceBefore - testCase.convertedAmount + testCase.dust
+          );
+
+          const balance = await encryptedERC.balanceOf(
+            ownerUser.signer.address,
+            1
+          );
+
+          const totalBalance = await getDecryptedBalance(
+            ownerUser.privateKey,
+            balance.amountPCTs,
+            balance.balancePCT,
+            balance.eGCT
+          );
+
+          expect(totalBalance).to.equal(
+            userEncryptedBalance + testCase.encryptedValue
+          );
+          userEncryptedBalance = totalBalance;
+        }
+      });
+
+      // this test should be here because it needs the encryptedERC to be initialized and deposit to be done
+      it("get tokens should return the proper addresses", async () => {
+        const contractTokens = await encryptedERC.getTokens();
+        expect(contractTokens).to.deep.equal([erc20s[1].target]);
+      });
+
+      it("should revert if user is not registered", async () => {
+        await expect(
+          encryptedERC.connect(users[5].signer).deposit(
+            1n,
+            users[0].signer.address,
+            Array.from({ length: 7 }, () => 1n)
+          )
+        ).to.be.reverted;
+      });
+    });
+
+    describe("Depositing Tokens - Lower ERC20 Decimals (6)", () => {
+      const mintAmount = 1000000000000000000000000n;
+      let userEncryptedBalance = 0n;
+
+      it("mint some tokens to the owner", async () => {
+        const erc20 = erc20s[0];
+
+        const tx = await erc20.connect(owner).mint(owner.address, mintAmount);
+        await tx.wait();
+
+        const balance = await erc20.balanceOf(owner.address);
+        expect(balance).to.equal(mintAmount);
+      });
+
+      it("should initialize user balance to 0", async () => {
+        const ownerUser = users[0];
+        const balance = await encryptedERC.getBalanceFromTokenAddress(
+          ownerUser.signer.address,
+          erc20s[0].target
+        );
+
+        const totalBalance = await getDecryptedBalance(
+          ownerUser.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+        userEncryptedBalance = totalBalance;
+      });
+
+      it("should deposit tokens to EncryptedERC and return the dust properly and mint the proper balance", async () => {
+        const ownerUser = users[0];
+
+        const cases = [
+          {
+            convertedAmount: 1_000_000n,
+            dust: 0n,
+            encryptedValue: 10_000_000_000n,
+          },
+          {
+            convertedAmount: 1_000_001n,
+            dust: 0n,
+            encryptedValue: 10_000_010_000n,
+          },
+          {
+            convertedAmount: 500_000n,
+            dust: 0n,
+            encryptedValue: 5_000_000_000n,
+          },
+          {
+            convertedAmount: 123_456_789n,
+            dust: 0n,
+            encryptedValue: 1_234_567_890_000n,
+          },
+        ];
+
+        const erc20 = erc20s[0];
+
+        for (const testCase of cases) {
+          // approve the deposit
+          await erc20
+            .connect(owner)
+            .approve(encryptedERC.target, testCase.convertedAmount);
+
+          const erc20BalanceBefore = await erc20.balanceOf(owner.address);
+
+          // need to create a new pct for the amount pct
+          const { ciphertext, nonce, authKey } = processPoseidonEncryption(
+            [testCase.encryptedValue],
+            ownerUser.publicKey
+          );
+
+          await encryptedERC
+            .connect(owner)
+            .deposit(testCase.convertedAmount, erc20.target, [
+              ...ciphertext,
+              ...authKey,
+              nonce,
+            ]);
+
+          const erc20BalanceAfter = await erc20.balanceOf(owner.address);
+          expect(erc20BalanceAfter).to.equal(
+            erc20BalanceBefore - testCase.convertedAmount + testCase.dust
+          );
+
+          const balance = await encryptedERC.balanceOf(
+            ownerUser.signer.address,
+            2
+          );
+
+          const totalBalance = await getDecryptedBalance(
+            ownerUser.privateKey,
+            balance.amountPCTs,
+            balance.balancePCT,
+            balance.eGCT
+          );
+
+          expect(totalBalance).to.equal(
+            userEncryptedBalance + testCase.encryptedValue
+          );
+          userEncryptedBalance = totalBalance;
+        }
+      });
+
+      it("get tokens should return the proper addresses", async () => {
+        const contractTokens = await encryptedERC.getTokens();
+        expect(contractTokens).to.deep.equal([
+          erc20s[1].target,
+          erc20s[0].target,
+        ]);
+      });
+
+      it("should revert of user does not have enough token or enough approval for the deposit", async () => {
+        const user = users[1];
+
+        await expect(
+          encryptedERC.connect(user.signer).deposit(
+            1n,
+            erc20s[0].target,
+            Array.from({ length: 7 }, () => 1n)
+          )
+        ).to.be.reverted;
+      });
+    });
+
+    describe("Depositing Tokens - Same ERC20 Decimals (10)", () => {
+      const mintAmount = 1000000000000000000000000n;
+      let userEncryptedBalance = 0n;
+
+      it("mint some tokens to the owner", async () => {
+        const erc20 = erc20s[2];
+
+        const tx = await erc20.connect(owner).mint(owner.address, mintAmount);
+        await tx.wait();
+
+        const balance = await erc20.balanceOf(owner.address);
+        expect(balance).to.equal(mintAmount);
+      });
+
+      it("should initialize user balance to 0", async () => {
+        const ownerUser = users[0];
+        const balance = await encryptedERC.balanceOf(
+          ownerUser.signer.address,
+          3
+        );
+
+        const totalBalance = await getDecryptedBalance(
+          ownerUser.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+        userEncryptedBalance = totalBalance;
+      });
+
+      it("should deposit tokens to EncryptedERC and return the dust properly and mint the proper balance", async () => {
+        const ownerUser = users[0];
+
+        const cases = [
+          {
+            convertedAmount: 1_000_000_000n,
+            dust: 0n,
+            encryptedValue: 1_000_000_000n,
+          },
+          {
+            convertedAmount: 123_456_789_000n,
+            dust: 0n,
+            encryptedValue: 123_456_789_000n,
+          },
+          {
+            convertedAmount: 50_000_000_000n,
+            dust: 0n,
+            encryptedValue: 50_000_000_000n,
+          },
+          {
+            convertedAmount: 1_000n,
+            dust: 0n,
+            encryptedValue: 1_000n,
+          },
+          {
+            convertedAmount: 999_999_999_999n,
+            dust: 0n,
+            encryptedValue: 999_999_999_999n,
+          },
+        ];
+
+        const erc20 = erc20s[2];
+
+        for (const testCase of cases) {
+          // approve the deposit
+          await erc20
+            .connect(owner)
+            .approve(encryptedERC.target, testCase.convertedAmount);
+
+          const erc20BalanceBefore = await erc20.balanceOf(owner.address);
+
+          // need to create a new pct for the amount pct
+          const { ciphertext, nonce, authKey } = processPoseidonEncryption(
+            [testCase.encryptedValue],
+            ownerUser.publicKey
+          );
+
+          await encryptedERC
+            .connect(owner)
+            .deposit(testCase.convertedAmount, erc20.target, [
+              ...ciphertext,
+              ...authKey,
+              nonce,
+            ]);
+
+          const erc20BalanceAfter = await erc20.balanceOf(owner.address);
+          expect(erc20BalanceAfter).to.equal(
+            erc20BalanceBefore - testCase.convertedAmount + testCase.dust
+          );
+
+          const balance = await encryptedERC.balanceOf(
+            ownerUser.signer.address,
+            3
+          );
+
+          const totalBalance = await getDecryptedBalance(
+            ownerUser.privateKey,
+            balance.amountPCTs,
+            balance.balancePCT,
+            balance.eGCT
+          );
+
+          expect(totalBalance).to.equal(
+            userEncryptedBalance + testCase.encryptedValue
+          );
+          userEncryptedBalance = totalBalance;
+        }
+      });
+
+      it("get tokens should return the proper addresses", async () => {
+        const contractTokens = await encryptedERC.getTokens();
+        expect(contractTokens).to.deep.equal([
+          erc20s[1].target,
+          erc20s[0].target,
+          erc20s[2].target,
+        ]);
+      });
+    });
+
+    describe("Withdrawing Tokens - Lower ERC20 Decimals (6)", () => {
+      const tokenId = 2;
+      const withdrawAmount = 1000n;
+      let userInitialBalance: bigint;
+      let validProof: {
+        proof: string[];
+        publicInputs: string[];
+        userBalancePCT: string[];
+      };
+
+      it("should initialize user balance properly", async () => {
+        const user = users[0];
+
+        const balance = await encryptedERC.balanceOf(
+          user.signer.address,
+          tokenId
+        );
+
+        const totalBalance = await getDecryptedBalance(
+          user.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        userInitialBalance = totalBalance;
+      });
+
+      it("should withdraw token properly", async () => {
+        const user = users[0];
+        const balance = await encryptedERC.balanceOf(
+          user.signer.address,
+          tokenId
+        );
+        const userEncryptedBalance = [...balance.eGCT.c1, ...balance.eGCT.c2];
+
+        const { proof, publicInputs, userBalancePCT } = await withdraw(
+          withdrawAmount,
+          user,
+          userEncryptedBalance,
+          userInitialBalance,
+          auditorPublicKey
+        );
+
+        expect(
+          await encryptedERC
+            .connect(user.signer)
+            .withdraw(tokenId, proof, publicInputs, userBalancePCT)
+        ).to.be.not.reverted;
+
+        validProof = { proof, publicInputs, userBalancePCT };
+      });
+
+      it("after withdrawing, the user balance should be updated properly", async () => {
+        const user = users[0];
+        const balance = await encryptedERC.balanceOf(
+          user.signer.address,
+          tokenId
+        );
+
+        const totalBalance = await getDecryptedBalance(
+          user.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        expect(totalBalance).to.equal(userInitialBalance - withdrawAmount);
+      });
+
+      it("should revert if public keys are not matching", async () => {
+        const user = users[1];
+
+        await expect(
+          encryptedERC
+            .connect(user.signer)
+            .withdraw(
+              tokenId,
+              validProof.proof,
+              validProof.publicInputs,
+              validProof.userBalancePCT
+            )
+        ).to.be.revertedWithCustomError(encryptedERC, "InvalidProof");
+      });
+
+      it("should revert if auditor public key is not matching", async () => {
+        const _publicInputs = [...validProof.publicInputs];
+        _publicInputs[6] = "0";
+        _publicInputs[7] = "0";
+
+        await expect(
+          encryptedERC
+            .connect(users[0].signer)
+            .withdraw(
+              tokenId,
+              validProof.proof,
+              _publicInputs,
+              validProof.userBalancePCT
+            )
+        ).to.be.revertedWithCustomError(encryptedERC, "InvalidProof");
+      });
+
+      it("should revert if proof is not valid", async () => {
+        const user = users[0];
+        const _proof = [...validProof.proof];
+        _proof[0] = "0";
+
+        await expect(
+          encryptedERC
+            .connect(user.signer)
+            .withdraw(
+              tokenId,
+              validProof.proof,
+              validProof.publicInputs,
+              validProof.userBalancePCT
+            )
+        ).to.be.revertedWithCustomError(encryptedERC, "InvalidProof");
+      });
+
+      it("should revert if token is not registered", async () => {
+        const user = users[0];
+
+        await expect(
+          encryptedERC
+            .connect(user.signer)
+            .withdraw(
+              10n,
+              validProof.proof,
+              validProof.publicInputs,
+              validProof.userBalancePCT
+            )
+        ).to.be.revertedWithCustomError(encryptedERC, "UnknownToken");
+      });
+    });
+
+    describe("Withdrawing Tokens - Higher ERC20 Decimals (10)", () => {
+      const tokenId = 1;
+      const withdrawAmount = 10000n;
+      let userInitialBalance: bigint;
+      let validProof: {
+        proof: string[];
+        publicInputs: string[];
+        userBalancePCT: string[];
+      };
+
+      it("should initialize user balance properly", async () => {
+        const user = users[0];
+        const balance = await encryptedERC.balanceOf(
+          user.signer.address,
+          tokenId
+        );
+
+        const totalBalance = await getDecryptedBalance(
+          user.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        userInitialBalance = totalBalance;
+      });
+
+      it("should withdraw token properly", async () => {
+        const user = users[0];
+        const balance = await encryptedERC.balanceOf(
+          user.signer.address,
+          tokenId
+        );
+        const userEncryptedBalance = [...balance.eGCT.c1, ...balance.eGCT.c2];
+
+        const { proof, publicInputs, userBalancePCT } = await withdraw(
+          withdrawAmount,
+          user,
+          userEncryptedBalance,
+          userInitialBalance,
+          auditorPublicKey
+        );
+
+        expect(
+          await encryptedERC
+            .connect(user.signer)
+            .withdraw(tokenId, proof, publicInputs, userBalancePCT)
+        ).to.be.not.reverted;
+
+        validProof = { proof, publicInputs, userBalancePCT };
+      });
+
+      it("after withdrawing, the user balance should be updated properly", async () => {
+        const user = users[0];
+        const balance = await encryptedERC.balanceOf(
+          user.signer.address,
+          tokenId
+        );
+
+        const totalBalance = await getDecryptedBalance(
+          user.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        expect(totalBalance).to.equal(userInitialBalance - withdrawAmount);
+      });
+    });
+
+    describe("Transferring Tokens - 1", () => {
+      let senderBalance: bigint; // hardcoded for now from the deposit test
+      const transferAmount = 1000n;
+
+      it("sender balance should initialized properly", async () => {
+        const sender = users[0];
+
+        const balance = await encryptedERC.balanceOf(sender.signer.address, 1);
+
+        const totalBalance = await getDecryptedBalance(
+          sender.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        senderBalance = totalBalance;
+      });
+
+      it("should transfer tokens properly", async () => {
+        const sender = users[0];
+        const receiver = users[1];
+
+        const balance = await encryptedERC.balanceOf(sender.signer.address, 1);
+        const senderEncryptedBalance = [...balance.eGCT.c1, ...balance.eGCT.c2];
+
+        const { proof, publicInputs, senderBalancePCT } = await privateTransfer(
+          sender,
+          senderBalance,
+          receiver.publicKey,
+          transferAmount,
+          senderEncryptedBalance,
+          auditorPublicKey
+        );
+
+        expect(
+          await encryptedERC
+            .connect(sender.signer)
+            .transfer(
+              receiver.signer.address,
+              1n,
+              proof,
+              publicInputs,
+              senderBalancePCT
+            )
+        ).to.be.not.reverted;
+
+        senderBalance = senderBalance - transferAmount;
+      });
+
+      it("sender balance should be updated properly", async () => {
+        const sender = users[0];
+
+        const balance = await encryptedERC.balanceOf(sender.signer.address, 1);
+
+        const totalBalance = await getDecryptedBalance(
+          sender.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        expect(totalBalance).to.equal(senderBalance);
+      });
+
+      it("receiver balance should be updated properly", async () => {
+        const receiver = users[1];
+
+        const balance = await encryptedERC.balanceOf(
+          receiver.signer.address,
+          1
+        );
+
+        const totalBalance = await getDecryptedBalance(
+          receiver.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        expect(totalBalance).to.equal(transferAmount);
+      });
+    });
+
+    describe("Transferring Tokens - 2", () => {
+      let senderBalance: bigint; // hardcoded for now from the deposit test
+      const transferAmount = 1000n;
+
+      it("sender balance should initialized properly", async () => {
+        const sender = users[0];
+
+        const balance = await encryptedERC.balanceOf(sender.signer.address, 2);
+
+        const totalBalance = await getDecryptedBalance(
+          sender.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        senderBalance = totalBalance;
+      });
+
+      it("should transfer tokens properly", async () => {
+        const sender = users[0];
+        const receiver = users[1];
+
+        const balance = await encryptedERC.balanceOf(sender.signer.address, 2);
+        const senderEncryptedBalance = [...balance.eGCT.c1, ...balance.eGCT.c2];
+
+        const { proof, publicInputs, senderBalancePCT } = await privateTransfer(
+          sender,
+          senderBalance,
+          receiver.publicKey,
+          transferAmount,
+          senderEncryptedBalance,
+          auditorPublicKey
+        );
+
+        expect(
+          await encryptedERC
+            .connect(sender.signer)
+            .transfer(
+              receiver.signer.address,
+              2n,
+              proof,
+              publicInputs,
+              senderBalancePCT
+            )
+        ).to.be.not.reverted;
+
+        senderBalance = senderBalance - transferAmount;
+      });
+
+      it("sender balance should be updated properly", async () => {
+        const sender = users[0];
+
+        const balance = await encryptedERC.balanceOf(sender.signer.address, 2);
+
+        const totalBalance = await getDecryptedBalance(
+          sender.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        expect(totalBalance).to.equal(senderBalance);
+      });
+
+      it("receiver balance should be updated properly", async () => {
+        const receiver = users[1];
+
+        const balance = await encryptedERC.balanceOf(
+          receiver.signer.address,
+          2
+        );
+
+        const totalBalance = await getDecryptedBalance(
+          receiver.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        expect(totalBalance).to.equal(transferAmount);
+      });
+    });
+  });
 });

--- a/test/EncryptedERC-Standalone.ts
+++ b/test/EncryptedERC-Standalone.ts
@@ -3,8 +3,8 @@ import { expect, use } from "chai";
 import { ethers } from "hardhat";
 import type { Registrar } from "../typechain-types/contracts/Registrar";
 import {
-	EncryptedERC__factory,
-	Registrar__factory,
+  EncryptedERC__factory,
+  Registrar__factory,
 } from "../typechain-types/factories/contracts";
 
 import { Base8, mulPointEscalar } from "@zk-kit/baby-jubjub";
@@ -12,1121 +12,1120 @@ import { formatPrivKeyForBabyJub } from "maci-crypto";
 import { decryptPoint } from "../src/jub/jub";
 import type { EncryptedERC } from "../typechain-types/contracts/EncryptedERC";
 import {
-	decryptPCT,
-	deployLibrary,
-	deployVerifiers,
-	generateGnarkProof,
-	getDecryptedBalance,
-	privateBurn,
-	privateMint,
-	privateTransfer,
+  decryptPCT,
+  deployLibrary,
+  deployVerifiers,
+  generateGnarkProof,
+  getDecryptedBalance,
+  privateBurn,
+  privateMint,
+  privateTransfer,
 } from "./helpers";
 import { User } from "./user";
 
 const DECIMALS = 2;
 
 describe("EncryptedERC - Standalone", () => {
-	let registrar: Registrar;
-	let users: User[];
-	let signers: SignerWithAddress[];
-	let owner: SignerWithAddress;
-	let encryptedERC: EncryptedERC;
-
-	const deployFixture = async () => {
-		signers = await ethers.getSigners();
-		owner = signers[0];
-
-		const {
-			registrationVerifier,
-			mintVerifier,
-			withdrawVerifier,
-			transferVerifier,
-		} = await deployVerifiers(owner);
-		const babyJubJub = await deployLibrary(owner);
-
-		const registrarFactory = new Registrar__factory(owner);
-		const registrar_ = await registrarFactory
-			.connect(owner)
-			.deploy(registrationVerifier);
-
-		await registrar_.waitForDeployment();
-
-		const encryptedERCFactory = new EncryptedERC__factory({
-			"contracts/libraries/BabyJubJub.sol:BabyJubJub": babyJubJub,
-		});
-		const encryptedERC_ = await encryptedERCFactory.connect(owner).deploy({
-			_registrar: registrar_.target,
-			_isConverter: false,
-			_name: "Test",
-			_symbol: "TEST",
-			_mintVerifier: mintVerifier,
-			_withdrawVerifier: withdrawVerifier,
-			_transferVerifier: transferVerifier,
-			_decimals: DECIMALS,
-		});
-
-		await encryptedERC_.waitForDeployment();
-
-		registrar = registrar_;
-		encryptedERC = encryptedERC_;
-		users = signers.map((signer) => new User(signer));
-	};
-
-	before(async () => await deployFixture());
-
-	describe("Registrar", () => {
-		it("should deploy registrar properly", async () => {
-			expect(registrar.target).to.not.be.null;
-			expect(registrar).to.not.be.null;
-		});
-
-		it("should initialize properly", async () => {
-			const burnUserAddress = await registrar.BURN_USER();
-			const burnUserPublicKey = await registrar.userPublicKeys(burnUserAddress);
-			expect(burnUserPublicKey).to.deep.equal([0n, 1n]);
-		});
-
-		describe("Registration", () => {
-			let validParams: {
-				proof: string[];
-				publicInputs: string[];
-			};
-
-			it("users should be able to register properly", async () => {
-				// in register circuit we have 3 inputs
-				// private inputs = [senderPrivKey]
-				// public inputs = [senderPubKey[0], senderPubKey[1]]
-				for (const user of users.slice(0, 5)) {
-					const privateInputs = [
-						formatPrivKeyForBabyJub(user.privateKey).toString(),
-					];
-					const publicInputs = user.publicKey.map(String);
-					const input = {
-						privateInputs,
-						publicInputs,
-					};
-
-					const proof = await generateGnarkProof(
-						"REGISTER",
-						JSON.stringify(input),
-					);
-
-					const tx = await registrar
-						.connect(user.signer)
-						.register(
-							proof.map(BigInt),
-							publicInputs.map(BigInt) as [bigint, bigint],
-						);
-					await tx.wait();
-
-					// check if the user is registered
-					expect(await registrar.isUserRegistered(user.signer.address)).to.be
-						.true;
-
-					// and the public key is set
-					const contractPublicKey = await registrar.getUserPublicKey(
-						user.signer.address,
-					);
-					expect(contractPublicKey).to.deep.equal(user.publicKey);
-
-					validParams = { proof, publicInputs };
-				}
-			});
-
-			it("already registered user can not register again", async () => {
-				const alreadyRegisteredUser = users[0];
-
-				await expect(
-					registrar
-						.connect(alreadyRegisteredUser.signer)
-						.register(
-							validParams.proof.map(BigInt),
-							validParams.publicInputs.map(BigInt) as [bigint, bigint],
-						),
-				).to.be.revertedWith("UserAlreadyRegistered");
-			});
-		});
-	});
-
-	describe("EncryptedERC", () => {
-		let auditorPublicKey: [bigint, bigint];
-		let userBalance = 0n;
-
-		it("should initialize properly", async () => {
-			expect(encryptedERC.target).to.not.be.null;
-			expect(encryptedERC).to.not.be.null;
-
-			// since eerc is standalone name and symbol should be set
-			expect(await encryptedERC.name()).to.equal("Test");
-			expect(await encryptedERC.symbol()).to.equal("TEST");
-
-			// auditor key should not be set
-			expect(await encryptedERC.isAuditorKeySet()).to.be.false;
-		});
-
-		it("should revert if auditor key is not set", async () => {
-			await expect(
-				encryptedERC.connect(users[0].signer).privateMint(
-					users[0].signer.address,
-					Array.from({ length: 8 }, () => 1n),
-					Array.from({ length: 22 }, () => 1n),
-				),
-			).to.be.reverted;
-		});
-
-		describe("Auditor Key Set", () => {
-			it("should revert is user try to send transfer without an auditor key", async () => {
-				await expect(
-					encryptedERC.connect(users[0].signer).transfer(
-						users[0].signer.address,
-						users[1].signer.address,
-						Array.from({ length: 8 }, () => 1n),
-						Array.from({ length: 32 }, () => 1n),
-						Array.from({ length: 7 }, () => 1n),
-					),
-				).to.be.reverted;
-			});
-
-			it("only owner can set auditor key", async () => {
-				await expect(
-					encryptedERC
-						.connect(users[4].signer)
-						.setAuditorPublicKey(users[0].signer.address),
-				).to.be.reverted;
-			});
-
-			it("owner can set auditor key", async () => {
-				const tx = await encryptedERC
-					.connect(owner)
-					.setAuditorPublicKey(owner.address);
-				await tx.wait();
-
-				expect(await encryptedERC.isAuditorKeySet()).to.be.true;
-			});
-
-			it("auditor and auditor key should be set", async () => {
-				const auditor = await encryptedERC.auditor();
-				const auditorKey = await encryptedERC.auditorPublicKey();
-
-				expect(auditor).to.equal(users[0].signer.address);
-				expect(auditorKey).to.deep.equal([
-					users[0].publicKey[0],
-					users[0].publicKey[1],
-				]);
-
-				auditorPublicKey = [users[0].publicKey[0], users[0].publicKey[1]];
-			});
-
-			it("should revert if new auditor is not registered", async () => {
-				const nonRegisteredAuditor = users[5];
-
-				await expect(
-					encryptedERC
-						.connect(owner)
-						.setAuditorPublicKey(nonRegisteredAuditor.signer.address),
-				).to.be.reverted;
-			});
-
-			// must write here for pass the AuditorKeyNotSet error
-			it("should revert if user try to deposit", async () => {
-				await expect(
-					encryptedERC.connect(users[0].signer).deposit(
-						1n,
-						users[0].signer.address,
-						Array.from({ length: 7 }, () => 1n),
-					),
-				).to.be.revertedWithCustomError(encryptedERC, "InvalidOperation");
-			});
-
-			it("should revert if user try to withdraw", async () => {
-				await expect(
-					encryptedERC.connect(users[0].signer).withdraw(
-						1000n,
-						1n,
-						Array.from({ length: 8 }, () => 1n),
-						Array.from({ length: 16 }, () => 1n),
-						Array.from({ length: 7 }, () => 1n),
-					),
-				).to.be.revertedWithCustomError(encryptedERC, "InvalidOperation");
-			});
-		});
-
-		describe("Private Mint", () => {
-			const mintAmount = 10000n;
-			let validParamsForUser0: {
-				proof: string[];
-				publicInputs: string[];
-			};
-
-			it("after auditor key is set, only owner should be able to mint", async () => {
-				const receiver = users[0];
-				const receiverPublicKey = receiver.publicKey;
-
-				const { proof, publicInputs } = await privateMint(
-					mintAmount,
-					receiverPublicKey,
-					auditorPublicKey,
-				);
-
-				await encryptedERC
-					.connect(owner)
-					.privateMint(receiver.signer.address, proof, publicInputs);
-
-				validParamsForUser0 = { proof, publicInputs };
-			});
-
-			it("after private mint, balance should be updated properly", async () => {
-				const receiver = users[0];
-
-				const balance = await encryptedERC.balanceOfStandalone(
-					receiver.signer.address,
-				);
-
-				const totalBalance = await getDecryptedBalance(
-					receiver.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				expect(totalBalance).to.equal(mintAmount);
-				userBalance = totalBalance;
-			});
-
-			it("only owner can mint", async () => {
-				const nonOwner = users[5];
-
-				await expect(
-					encryptedERC.connect(nonOwner.signer).privateMint(
-						nonOwner.signer.address,
-						Array.from({ length: 8 }, () => 1n),
-						Array.from({ length: 22 }, () => 1n),
-					),
-				).to.be.reverted;
-			});
-
-			it("if destination user is not registered, mint should revert", async () => {
-				const nonRegisteredUser = users[5];
-
-				await expect(
-					encryptedERC.connect(owner).privateMint(
-						nonRegisteredUser.signer.address,
-						Array.from({ length: 8 }, () => 1n),
-						Array.from({ length: 22 }, () => 1n),
-					),
-				).to.be.reverted;
-			});
-
-			it("user public key and public key from proof should match, if not revert", async () => {
-				const notUser0 = users[4];
-
-				await expect(
-					encryptedERC
-						.connect(owner)
-						.privateMint(
-							notUser0.signer.address,
-							validParamsForUser0.proof,
-							validParamsForUser0.publicInputs,
-						),
-				).to.be.reverted;
-			});
-
-			it("auditor public key and auditor from proof should match, if not revert", async () => {
-				const receiver = users[0];
-
-				const _proof = validParamsForUser0.proof;
-				const _publicInputs = [...validParamsForUser0.publicInputs];
-
-				// auditor public key indexes are 13 and 14
-				// only change [13]
-				_publicInputs[13] = "100";
-				_publicInputs[14] = validParamsForUser0.publicInputs[14];
-
-				await expect(
-					encryptedERC
-						.connect(owner)
-						.privateMint(receiver.signer.address, _proof, _publicInputs),
-				).to.be.reverted;
-
-				// only change [14]
-				_publicInputs[13] = validParamsForUser0.publicInputs[13];
-				_publicInputs[14] = "100";
-
-				await expect(
-					encryptedERC
-						.connect(owner)
-						.privateMint(receiver.signer.address, _proof, _publicInputs),
-				).to.be.reverted;
-			});
-		});
-
-		describe("Private Burn", () => {
-			const burnAmount = 100n;
-			let validParams: {
-				proof: string[];
-				publicInputs: string[];
-				userBalancePCT: string[];
-			};
-
-			it("should burn properly", async () => {
-				const user = users[0];
-				const balance = await encryptedERC.balanceOfStandalone(
-					user.signer.address,
-				);
-
-				const userEncryptedBalance = [...balance.eGCT.c1, ...balance.eGCT.c2];
-				const userDecryptedBalance = await getDecryptedBalance(
-					user.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				const {
-					proof,
-					publicInputs,
-					senderBalancePCT: userBalancePCT,
-				} = await privateBurn(
-					user,
-					userDecryptedBalance,
-					burnAmount,
-					userEncryptedBalance,
-					auditorPublicKey,
-				);
-
-				await encryptedERC
-					.connect(user.signer)
-					.privateBurn(proof, publicInputs, userBalancePCT);
-
-				validParams = { proof, publicInputs, userBalancePCT };
-			});
-
-			it("should revert if proved balance is not valid", async () => {
-				const user = users[0];
-
-				await expect(
-					encryptedERC
-						.connect(user.signer)
-						.privateBurn(
-							validParams.proof,
-							validParams.publicInputs,
-							validParams.userBalancePCT,
-						),
-				).to.be.reverted;
-			});
-
-			it("users balance pct and elgamal ciphertext should be updated properly", async () => {
-				const user = users[0];
-				const balance = await encryptedERC.balanceOfStandalone(
-					user.signer.address,
-				);
-
-				const totalBalance = await getDecryptedBalance(
-					user.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				userBalance = totalBalance;
-			});
-
-			it("should revert if user is not registered", async () => {
-				const nonRegisteredUser = users[5];
-
-				await expect(
-					encryptedERC
-						.connect(nonRegisteredUser.signer)
-						.privateBurn(
-							validParams.proof,
-							validParams.publicInputs,
-							validParams.userBalancePCT,
-						),
-				).to.be.reverted;
-			});
-
-			it("user public key and public key from proof should match, if not revert", async () => {
-				const notUser0 = users[4];
-
-				await expect(
-					encryptedERC
-						.connect(notUser0.signer)
-						.privateBurn(
-							validParams.proof,
-							validParams.publicInputs,
-							validParams.userBalancePCT,
-						),
-				).to.be.reverted;
-			});
-
-			it("auditor public key and auditor from proof should match, if not revert", async () => {
-				const user = users[0];
-
-				const _proof = validParams.proof;
-				const _publicInputs = [...validParams.publicInputs];
-
-				// auditor public key indexes are 23 and 24
-				// only change [23]
-				_publicInputs[23] = "100";
-				_publicInputs[24] = validParams.publicInputs[24];
-
-				await expect(
-					encryptedERC
-						.connect(user.signer)
-						.privateBurn(_proof, _publicInputs, validParams.userBalancePCT),
-				).to.be.reverted;
-
-				// only change [24]
-				_publicInputs[23] = validParams.publicInputs[23];
-				_publicInputs[24] = "100";
-
-				await expect(
-					encryptedERC
-						.connect(user.signer)
-						.privateBurn(_proof, _publicInputs, validParams.userBalancePCT),
-				).to.be.reverted;
-			});
-		});
-
-		// In order to test front running protection what we can do is to
-		// 0. owner mints some tokens to userA
-		// 1. userA creates a burn proof but do not send it to the contract
-		// 2. owner mints some tokens to userA repeatedly so userA's amount PCTs are updated
-		// 3. userA sends his burn proof
-		// after step 3, burn proof should be valid and need to updated pcts accordingly
-		describe("Front Running Protection", () => {
-			const INITIAL_MINT_COUNT = 4;
-			const SECOND_MINT_COUNT = 5;
-			const PER_MINT = 100n;
-			const EXPECTED_BALANCE_AFTER_INITIAL_MINT = 1000n;
-			const EXPECTED_BALANCE_AFTER_MINT = 2500n;
-
-			const burnAmount = 100n;
-			let userABalance = 0n;
-
-			let burnProof: {
-				proof: string[];
-				publicInputs: string[];
-				senderBalancePCT: string[];
-			};
-
-			it("0. owner mints some tokens to userA", async () => {
-				console.log("UserA Initial Balance", userABalance);
-
-				const userA = users[1];
-
-				for (let i = 0; i < INITIAL_MINT_COUNT; i++) {
-					const receiverPublicKey = userA.publicKey;
-					const mintAmount = PER_MINT * BigInt(i + 1);
-					const { proof, publicInputs } = await privateMint(
-						mintAmount,
-						receiverPublicKey,
-						auditorPublicKey,
-					);
-
-					await encryptedERC
-						.connect(owner)
-						.privateMint(userA.signer.address, proof, publicInputs);
-				}
-			});
-
-			it("userA balance should be updated properly", async () => {
-				const userA = users[1];
-
-				const balance = await encryptedERC.balanceOfStandalone(
-					userA.signer.address,
-				);
-
-				const totalBalance = await getDecryptedBalance(
-					userA.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				const amountPCTs = balance.amountPCTs;
-
-				const decryptedAmountPCTs = [];
-				for (const [pct] of amountPCTs) {
-					const decrypted = await decryptPCT(userA.privateKey, pct);
-					decryptedAmountPCTs.push(decrypted[0]);
-				}
-
-				expect(totalBalance).to.deep.equal(EXPECTED_BALANCE_AFTER_INITIAL_MINT);
-				userABalance = totalBalance;
-
-				console.log(
-					"UserA Balance After Initial Mint",
-					userABalance,
-					"has",
-					amountPCTs.length,
-					`amount pcts in contract before generating burn proof and has ${decryptedAmountPCTs.length} different amount pcts that have`,
-					decryptedAmountPCTs,
-				);
-			});
-
-			it("1. userA creates a burn proof but do not send it to the contract", async () => {
-				const userA = users[1];
-				const balance = await encryptedERC.balanceOfStandalone(
-					userA.signer.address,
-				);
-
-				const userEncryptedBalance = [...balance.eGCT.c1, ...balance.eGCT.c2];
-
-				const { proof, publicInputs, senderBalancePCT } = await privateBurn(
-					userA,
-					userABalance,
-					burnAmount,
-					userEncryptedBalance,
-					auditorPublicKey,
-				);
-
-				burnProof = { proof, publicInputs, senderBalancePCT };
-			});
-
-			it("2. owner mints some tokens to userA repeatedly so userA's amount PCTs are updated", async () => {
-				const userA = users[1];
-
-				for (let i = 0; i < SECOND_MINT_COUNT; i++) {
-					const receiverPublicKey = userA.publicKey;
-
-					const { proof, publicInputs } = await privateMint(
-						PER_MINT * BigInt(i + 1),
-						receiverPublicKey,
-						auditorPublicKey,
-					);
-
-					await encryptedERC
-						.connect(owner)
-						.privateMint(userA.signer.address, proof, publicInputs);
-				}
-			});
-
-			it("userA balance should be updated properly", async () => {
-				const userA = users[1];
-
-				const balance = await encryptedERC.balanceOfStandalone(
-					userA.signer.address,
-				);
-
-				const totalBalance = await getDecryptedBalance(
-					userA.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				const amountPCTs = balance.amountPCTs;
-
-				const decryptedAmountPCTs = [];
-				for (const [pct] of amountPCTs) {
-					const decrypted = await decryptPCT(userA.privateKey, pct);
-					decryptedAmountPCTs.push(decrypted[0]);
-				}
-
-				expect(totalBalance).to.deep.equal(EXPECTED_BALANCE_AFTER_MINT);
-				userABalance = totalBalance;
-
-				console.log(
-					"UserA Balance After Second Mint",
-					userABalance,
-					"has",
-					amountPCTs.length,
-					"amount pcts in contract and has",
-					decryptedAmountPCTs,
-				);
-			});
-
-			it("3. userA sends his burn proof", async () => {
-				const userA = users[1];
-
-				await encryptedERC
-					.connect(userA.signer)
-					.privateBurn(
-						burnProof.proof,
-						burnProof.publicInputs,
-						burnProof.senderBalancePCT,
-					);
-
-				console.log("userA balance before burn", userABalance);
-				userABalance = userABalance - burnAmount;
-				console.log("userA balance after burn", userABalance);
-			});
-
-			it("after that amount pcts should be updated properly", async () => {
-				const userA = users[1];
-
-				const balance = await encryptedERC.balanceOfStandalone(
-					userA.signer.address,
-				);
-
-				const totalBalance = await getDecryptedBalance(
-					userA.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				const decryptedBalancePCT = await decryptPCT(
-					userA.privateKey,
-					balance.balancePCT,
-				);
-
-				const amountPCTs = balance.amountPCTs;
-				const decryptedAmountPCTs = [];
-				for (const [pct] of amountPCTs) {
-					const decrypted = await decryptPCT(userA.privateKey, pct);
-					decryptedAmountPCTs.push(decrypted[0]);
-				}
-
-				console.log("decryptedAmountPCTs", decryptedAmountPCTs);
-
-				expect(totalBalance).to.deep.equal(userABalance);
-				userABalance = totalBalance;
-
-				console.log(
-					"UserA Balance After Burn",
-					userABalance,
-					"has",
-					amountPCTs.length,
-					"amount pcts in contract and has",
-					decryptedAmountPCTs,
-					"and balance pct is",
-					decryptedBalancePCT[0],
-				);
-			});
-
-			it("userA can burn again", async () => {
-				const userA = users[1];
-				const balance = await encryptedERC.balanceOfStandalone(
-					userA.signer.address,
-				);
-
-				const userEncryptedBalance = [...balance.eGCT.c1, ...balance.eGCT.c2];
-
-				const { proof, publicInputs, senderBalancePCT } = await privateBurn(
-					userA,
-					userABalance,
-					burnAmount,
-					userEncryptedBalance,
-					auditorPublicKey,
-				);
-
-				await encryptedERC
-					.connect(userA.signer)
-					.privateBurn(proof, publicInputs, senderBalancePCT);
-
-				console.log("userA balance before burn", userABalance);
-				userABalance = userABalance - burnAmount;
-				console.log("userA balance after burn", userABalance);
-			});
-
-			it("after that amount pcts should be updated properly", async () => {
-				const userA = users[1];
-
-				const balance = await encryptedERC.balanceOfStandalone(
-					userA.signer.address,
-				);
-
-				const totalBalance = await getDecryptedBalance(
-					userA.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				const decryptedBalancePCT = await decryptPCT(
-					userA.privateKey,
-					balance.balancePCT,
-				);
-
-				const amountPCTs = balance.amountPCTs;
-				const decryptedAmountPCTs = [];
-				for (const [pct] of amountPCTs) {
-					const decrypted = await decryptPCT(userA.privateKey, pct);
-					decryptedAmountPCTs.push(decrypted[0]);
-				}
-
-				expect(totalBalance).to.deep.equal(userABalance);
-				userABalance = totalBalance;
-
-				console.log(
-					"UserA Balance After Burn",
-					userABalance,
-					"has",
-					amountPCTs.length,
-					"amount pcts in contract and has",
-					decryptedAmountPCTs,
-					"and balance pct is",
-					decryptedBalancePCT[0],
-				);
-			});
-
-			it("userA can burn again", async () => {
-				const userA = users[1];
-				const balance = await encryptedERC.balanceOfStandalone(
-					userA.signer.address,
-				);
-
-				const userEncryptedBalance = [...balance.eGCT.c1, ...balance.eGCT.c2];
-
-				const { proof, publicInputs, senderBalancePCT } = await privateBurn(
-					userA,
-					userABalance,
-					burnAmount,
-					userEncryptedBalance,
-					auditorPublicKey,
-				);
-
-				await encryptedERC
-					.connect(userA.signer)
-					.privateBurn(proof, publicInputs, senderBalancePCT);
-
-				console.log("userA balance before burn", userABalance);
-				userABalance = userABalance - burnAmount;
-				console.log("userA balance after burn", userABalance);
-			});
-
-			it("after that amount pcts should be updated properly", async () => {
-				const userA = users[1];
-
-				const balance = await encryptedERC.balanceOfStandalone(
-					userA.signer.address,
-				);
-
-				const totalBalance = await getDecryptedBalance(
-					userA.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				const decryptedBalancePCT = await decryptPCT(
-					userA.privateKey,
-					balance.balancePCT,
-				);
-
-				const amountPCTs = balance.amountPCTs;
-				const decryptedAmountPCTs = [];
-				for (const [pct] of amountPCTs) {
-					const decrypted = await decryptPCT(userA.privateKey, pct);
-					decryptedAmountPCTs.push(decrypted[0]);
-				}
-
-				expect(totalBalance).to.deep.equal(userABalance);
-				userABalance = totalBalance;
-
-				console.log(
-					"UserA Balance After Burn",
-					userABalance,
-					"has",
-					amountPCTs.length,
-					"amount pcts in contract and has",
-					decryptedAmountPCTs,
-					"and balance pct is",
-					decryptedBalancePCT[0],
-				);
-			});
-		});
-
-		describe("Private Transfer", () => {
-			let senderBalance = 0n;
-			const transferAmount = 500n;
-			let validParams: {
-				to: string;
-				proof: string[];
-				publicInputs: string[];
-				senderBalancePCT: string[];
-			};
-
-			it("sender needs to calculate the encrypted balance", async () => {
-				const sender = users[0];
-
-				const balance = await encryptedERC.balanceOfStandalone(
-					sender.signer.address,
-				);
-
-				const totalBalance = await getDecryptedBalance(
-					sender.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				const decryptedBalance = decryptPoint(
-					sender.privateKey,
-					balance.eGCT.c1,
-					balance.eGCT.c2,
-				);
-
-				const expectedPoint = mulPointEscalar(Base8, totalBalance);
-				expect(decryptedBalance).to.deep.equal(expectedPoint);
-
-				senderBalance = totalBalance;
-				console.log("Before transfer sender balance is", senderBalance);
-				console.log("Before transfer receiver balance is", 0n);
-			});
-
-			it("should transfer properly", async () => {
-				const sender = users[0];
-				const receiver = users[4];
-
-				const senderEncryptedBalance = await encryptedERC.balanceOfStandalone(
-					sender.signer.address,
-				);
-
-				const { proof, publicInputs, senderBalancePCT } = await privateTransfer(
-					sender,
-					senderBalance,
-					receiver.publicKey,
-					transferAmount,
-					[
-						...senderEncryptedBalance.eGCT.c1,
-						...senderEncryptedBalance.eGCT.c2,
-					],
-					auditorPublicKey,
-				);
-
-				expect(
-					await encryptedERC
-						.connect(sender.signer)
-						.transfer(
-							receiver.signer.address,
-							0n,
-							proof,
-							publicInputs,
-							senderBalancePCT,
-						),
-				).to.be.not.reverted;
-
-				validParams = {
-					proof,
-					publicInputs,
-					senderBalancePCT,
-					to: receiver.signer.address,
-				};
-
-				console.log("Sender transfers", transferAmount, "to receiver");
-			});
-
-			it("should revert if sender provided balance is not valid", async () => {
-				const user = users[0];
-
-				await expect(
-					encryptedERC
-						.connect(user.signer)
-						.transfer(
-							validParams.to,
-							0n,
-							validParams.proof,
-							validParams.publicInputs,
-							validParams.senderBalancePCT,
-						),
-				).to.be.reverted;
-			});
-
-			it("sender balance should be updated properly", async () => {
-				const senderExpectedNewBalance = senderBalance - transferAmount;
-				const sender = users[0];
-
-				const balance = await encryptedERC.balanceOfStandalone(
-					sender.signer.address,
-				);
-
-				const totalBalance = await getDecryptedBalance(
-					sender.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				const decryptedBalance = decryptPoint(
-					sender.privateKey,
-					balance.eGCT.c1,
-					balance.eGCT.c2,
-				);
-
-				expect(totalBalance).to.equal(senderExpectedNewBalance);
-				const expectedPoint = mulPointEscalar(Base8, totalBalance);
-				expect(decryptedBalance).to.deep.equal(expectedPoint);
-
-				console.log("After transfer sender balance is", senderBalance);
-			});
-
-			it("receiver balance should be updated properly", async () => {
-				const receiver = users[4];
-
-				const balance = await encryptedERC.balanceOfStandalone(
-					receiver.signer.address,
-				);
-
-				const totalBalance = await getDecryptedBalance(
-					receiver.privateKey,
-					balance.amountPCTs,
-					balance.balancePCT,
-					balance.eGCT,
-				);
-
-				const decryptedBalance = decryptPoint(
-					receiver.privateKey,
-					balance.eGCT.c1,
-					balance.eGCT.c2,
-				);
-
-				expect(totalBalance).to.equal(transferAmount); // ?
-				const expectedPoint = mulPointEscalar(Base8, totalBalance);
-				expect(decryptedBalance).to.deep.equal(expectedPoint);
-
-				console.log("After transfer receiver balance is", totalBalance);
-			});
-
-			it("should revert is 'to' is not registered", async () => {
-				const nonRegisteredUser = users[5];
-
-				await expect(
-					encryptedERC
-						.connect(users[0].signer)
-						.transfer(
-							nonRegisteredUser.signer.address,
-							0n,
-							validParams.proof,
-							validParams.publicInputs,
-							validParams.senderBalancePCT,
-						),
-				).to.be.reverted;
-			});
-
-			it("should revert is 'from' is not registered", async () => {
-				const nonRegisteredUser = users[5];
-
-				await expect(
-					encryptedERC
-						.connect(nonRegisteredUser.signer)
-						.transfer(
-							users[0].signer.address,
-							0n,
-							validParams.proof,
-							validParams.publicInputs,
-							validParams.senderBalancePCT,
-						),
-				).to.be.reverted;
-			});
-
-			it("should revert if sender public key and public key from proof do not match ", async () => {
-				// fromPublicKey is at index 0 and 1
-				// only change [0]
-				const _proof = validParams.proof;
-				const _publicInputs = [...validParams.publicInputs];
-
-				_publicInputs[0] = "100";
-				_publicInputs[1] = validParams.publicInputs[1];
-
-				await expect(
-					encryptedERC
-						.connect(users[0].signer)
-						.transfer(
-							validParams.to,
-							0n,
-							_proof,
-							_publicInputs,
-							validParams.senderBalancePCT,
-						),
-				).to.be.reverted;
-
-				// change [1]
-				_publicInputs[0] = validParams.publicInputs[0];
-				_publicInputs[1] = "100";
-
-				await expect(
-					encryptedERC
-						.connect(users[0].signer)
-						.transfer(
-							validParams.to,
-							0n,
-							_proof,
-							_publicInputs,
-							validParams.senderBalancePCT,
-						),
-				).to.be.reverted;
-			});
-
-			it("should revert if receiver public key and public key from proof do not match", async () => {
-				// toPublicKey is at index 10 and 11
-				// only change [10]
-				const _proof = validParams.proof;
-				const _publicInputs = [...validParams.publicInputs];
-
-				_publicInputs[10] = "100";
-				_publicInputs[11] = validParams.publicInputs[11];
-
-				await expect(
-					encryptedERC
-						.connect(users[0].signer)
-						.transfer(
-							validParams.to,
-							0n,
-							_proof,
-							_publicInputs,
-							validParams.senderBalancePCT,
-						),
-				).to.be.reverted;
-
-				// only change [11]
-				_publicInputs[10] = validParams.publicInputs[10];
-				_publicInputs[11] = "100";
-
-				await expect(
-					encryptedERC
-						.connect(users[0].signer)
-						.transfer(
-							validParams.to,
-							0n,
-							_proof,
-							_publicInputs,
-							validParams.senderBalancePCT,
-						),
-				).to.be.reverted;
-			});
-
-			it("should revert if auditor public key is not match with public key in proof", async () => {
-				const receiver = users[0];
-
-				const _proof = validParams.proof;
-				const _publicInputs = [...validParams.publicInputs];
-
-				// auditor public key indexes are 23 and 24
-				// only change [23]
-				_publicInputs[23] = "100";
-				_publicInputs[24] = validParams.publicInputs[24];
-
-				await expect(
-					encryptedERC
-						.connect(owner)
-						.transfer(
-							validParams.to,
-							0n,
-							_proof,
-							_publicInputs,
-							validParams.senderBalancePCT,
-						),
-				).to.be.reverted;
-
-				// only change [24]
-				_publicInputs[23] = validParams.publicInputs[23];
-				_publicInputs[24] = "100";
-
-				await expect(
-					encryptedERC
-						.connect(owner)
-						.transfer(
-							validParams.to,
-							0n,
-							_proof,
-							_publicInputs,
-							validParams.senderBalancePCT,
-						),
-				).to.be.reverted;
-			});
-		});
-	});
+  let registrar: Registrar;
+  let users: User[];
+  let signers: SignerWithAddress[];
+  let owner: SignerWithAddress;
+  let encryptedERC: EncryptedERC;
+
+  const deployFixture = async () => {
+    signers = await ethers.getSigners();
+    owner = signers[0];
+
+    const {
+      registrationVerifier,
+      mintVerifier,
+      withdrawVerifier,
+      transferVerifier,
+    } = await deployVerifiers(owner);
+    const babyJubJub = await deployLibrary(owner);
+
+    const registrarFactory = new Registrar__factory(owner);
+    const registrar_ = await registrarFactory
+      .connect(owner)
+      .deploy(registrationVerifier);
+
+    await registrar_.waitForDeployment();
+
+    const encryptedERCFactory = new EncryptedERC__factory({
+      "contracts/libraries/BabyJubJub.sol:BabyJubJub": babyJubJub,
+    });
+    const encryptedERC_ = await encryptedERCFactory.connect(owner).deploy({
+      _registrar: registrar_.target,
+      _isConverter: false,
+      _name: "Test",
+      _symbol: "TEST",
+      _mintVerifier: mintVerifier,
+      _withdrawVerifier: withdrawVerifier,
+      _transferVerifier: transferVerifier,
+      _decimals: DECIMALS,
+    });
+
+    await encryptedERC_.waitForDeployment();
+
+    registrar = registrar_;
+    encryptedERC = encryptedERC_;
+    users = signers.map((signer) => new User(signer));
+  };
+
+  before(async () => await deployFixture());
+
+  describe("Registrar", () => {
+    it("should deploy registrar properly", async () => {
+      expect(registrar.target).to.not.be.null;
+      expect(registrar).to.not.be.null;
+    });
+
+    it("should initialize properly", async () => {
+      const burnUserAddress = await registrar.BURN_USER();
+      const burnUserPublicKey = await registrar.userPublicKeys(burnUserAddress);
+      expect(burnUserPublicKey).to.deep.equal([0n, 1n]);
+    });
+
+    describe("Registration", () => {
+      let validParams: {
+        proof: string[];
+        publicInputs: string[];
+      };
+
+      it("users should be able to register properly", async () => {
+        // in register circuit we have 3 inputs
+        // private inputs = [senderPrivKey]
+        // public inputs = [senderPubKey[0], senderPubKey[1]]
+        for (const user of users.slice(0, 5)) {
+          const privateInputs = [
+            formatPrivKeyForBabyJub(user.privateKey).toString(),
+          ];
+          const publicInputs = user.publicKey.map(String);
+          const input = {
+            privateInputs,
+            publicInputs,
+          };
+
+          const proof = await generateGnarkProof(
+            "REGISTER",
+            JSON.stringify(input)
+          );
+
+          const tx = await registrar
+            .connect(user.signer)
+            .register(
+              proof.map(BigInt),
+              publicInputs.map(BigInt) as [bigint, bigint]
+            );
+          await tx.wait();
+
+          // check if the user is registered
+          expect(await registrar.isUserRegistered(user.signer.address)).to.be
+            .true;
+
+          // and the public key is set
+          const contractPublicKey = await registrar.getUserPublicKey(
+            user.signer.address
+          );
+          expect(contractPublicKey).to.deep.equal(user.publicKey);
+
+          validParams = { proof, publicInputs };
+        }
+      });
+
+      it("already registered user can not register again", async () => {
+        const alreadyRegisteredUser = users[0];
+
+        await expect(
+          registrar
+            .connect(alreadyRegisteredUser.signer)
+            .register(
+              validParams.proof.map(BigInt),
+              validParams.publicInputs.map(BigInt) as [bigint, bigint]
+            )
+        ).to.be.revertedWith("UserAlreadyRegistered");
+      });
+    });
+  });
+
+  describe("EncryptedERC", () => {
+    let auditorPublicKey: [bigint, bigint];
+    let userBalance = 0n;
+
+    it("should initialize properly", async () => {
+      expect(encryptedERC.target).to.not.be.null;
+      expect(encryptedERC).to.not.be.null;
+
+      // since eerc is standalone name and symbol should be set
+      expect(await encryptedERC.name()).to.equal("Test");
+      expect(await encryptedERC.symbol()).to.equal("TEST");
+
+      // auditor key should not be set
+      expect(await encryptedERC.isAuditorKeySet()).to.be.false;
+    });
+
+    it("should revert if auditor key is not set", async () => {
+      await expect(
+        encryptedERC.connect(users[0].signer).privateMint(
+          users[0].signer.address,
+          Array.from({ length: 8 }, () => 1n),
+          Array.from({ length: 22 }, () => 1n)
+        )
+      ).to.be.reverted;
+    });
+
+    describe("Auditor Key Set", () => {
+      it("should revert is user try to send transfer without an auditor key", async () => {
+        await expect(
+          encryptedERC.connect(users[0].signer).transfer(
+            users[0].signer.address,
+            users[1].signer.address,
+            Array.from({ length: 8 }, () => 1n),
+            Array.from({ length: 32 }, () => 1n),
+            Array.from({ length: 7 }, () => 1n)
+          )
+        ).to.be.reverted;
+      });
+
+      it("only owner can set auditor key", async () => {
+        await expect(
+          encryptedERC
+            .connect(users[4].signer)
+            .setAuditorPublicKey(users[0].signer.address)
+        ).to.be.reverted;
+      });
+
+      it("owner can set auditor key", async () => {
+        const tx = await encryptedERC
+          .connect(owner)
+          .setAuditorPublicKey(owner.address);
+        await tx.wait();
+
+        expect(await encryptedERC.isAuditorKeySet()).to.be.true;
+      });
+
+      it("auditor and auditor key should be set", async () => {
+        const auditor = await encryptedERC.auditor();
+        const auditorKey = await encryptedERC.auditorPublicKey();
+
+        expect(auditor).to.equal(users[0].signer.address);
+        expect(auditorKey).to.deep.equal([
+          users[0].publicKey[0],
+          users[0].publicKey[1],
+        ]);
+
+        auditorPublicKey = [users[0].publicKey[0], users[0].publicKey[1]];
+      });
+
+      it("should revert if new auditor is not registered", async () => {
+        const nonRegisteredAuditor = users[5];
+
+        await expect(
+          encryptedERC
+            .connect(owner)
+            .setAuditorPublicKey(nonRegisteredAuditor.signer.address)
+        ).to.be.reverted;
+      });
+
+      // must write here for pass the AuditorKeyNotSet error
+      it("should revert if user try to deposit", async () => {
+        await expect(
+          encryptedERC.connect(users[0].signer).deposit(
+            1n,
+            users[0].signer.address,
+            Array.from({ length: 7 }, () => 1n)
+          )
+        ).to.be.revertedWithCustomError(encryptedERC, "InvalidOperation");
+      });
+
+      it("should revert if user try to withdraw", async () => {
+        await expect(
+          encryptedERC.connect(users[0].signer).withdraw(
+            1n,
+            Array.from({ length: 8 }, () => 1n),
+            Array.from({ length: 16 }, () => 1n),
+            Array.from({ length: 7 }, () => 1n)
+          )
+        ).to.be.revertedWithCustomError(encryptedERC, "InvalidOperation");
+      });
+    });
+
+    describe("Private Mint", () => {
+      const mintAmount = 10000n;
+      let validParamsForUser0: {
+        proof: string[];
+        publicInputs: string[];
+      };
+
+      it("after auditor key is set, only owner should be able to mint", async () => {
+        const receiver = users[0];
+        const receiverPublicKey = receiver.publicKey;
+
+        const { proof, publicInputs } = await privateMint(
+          mintAmount,
+          receiverPublicKey,
+          auditorPublicKey
+        );
+
+        await encryptedERC
+          .connect(owner)
+          .privateMint(receiver.signer.address, proof, publicInputs);
+
+        validParamsForUser0 = { proof, publicInputs };
+      });
+
+      it("after private mint, balance should be updated properly", async () => {
+        const receiver = users[0];
+
+        const balance = await encryptedERC.balanceOfStandalone(
+          receiver.signer.address
+        );
+
+        const totalBalance = await getDecryptedBalance(
+          receiver.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        expect(totalBalance).to.equal(mintAmount);
+        userBalance = totalBalance;
+      });
+
+      it("only owner can mint", async () => {
+        const nonOwner = users[5];
+
+        await expect(
+          encryptedERC.connect(nonOwner.signer).privateMint(
+            nonOwner.signer.address,
+            Array.from({ length: 8 }, () => 1n),
+            Array.from({ length: 22 }, () => 1n)
+          )
+        ).to.be.reverted;
+      });
+
+      it("if destination user is not registered, mint should revert", async () => {
+        const nonRegisteredUser = users[5];
+
+        await expect(
+          encryptedERC.connect(owner).privateMint(
+            nonRegisteredUser.signer.address,
+            Array.from({ length: 8 }, () => 1n),
+            Array.from({ length: 22 }, () => 1n)
+          )
+        ).to.be.reverted;
+      });
+
+      it("user public key and public key from proof should match, if not revert", async () => {
+        const notUser0 = users[4];
+
+        await expect(
+          encryptedERC
+            .connect(owner)
+            .privateMint(
+              notUser0.signer.address,
+              validParamsForUser0.proof,
+              validParamsForUser0.publicInputs
+            )
+        ).to.be.reverted;
+      });
+
+      it("auditor public key and auditor from proof should match, if not revert", async () => {
+        const receiver = users[0];
+
+        const _proof = validParamsForUser0.proof;
+        const _publicInputs = [...validParamsForUser0.publicInputs];
+
+        // auditor public key indexes are 13 and 14
+        // only change [13]
+        _publicInputs[13] = "100";
+        _publicInputs[14] = validParamsForUser0.publicInputs[14];
+
+        await expect(
+          encryptedERC
+            .connect(owner)
+            .privateMint(receiver.signer.address, _proof, _publicInputs)
+        ).to.be.reverted;
+
+        // only change [14]
+        _publicInputs[13] = validParamsForUser0.publicInputs[13];
+        _publicInputs[14] = "100";
+
+        await expect(
+          encryptedERC
+            .connect(owner)
+            .privateMint(receiver.signer.address, _proof, _publicInputs)
+        ).to.be.reverted;
+      });
+    });
+
+    describe("Private Burn", () => {
+      const burnAmount = 100n;
+      let validParams: {
+        proof: string[];
+        publicInputs: string[];
+        userBalancePCT: string[];
+      };
+
+      it("should burn properly", async () => {
+        const user = users[0];
+        const balance = await encryptedERC.balanceOfStandalone(
+          user.signer.address
+        );
+
+        const userEncryptedBalance = [...balance.eGCT.c1, ...balance.eGCT.c2];
+        const userDecryptedBalance = await getDecryptedBalance(
+          user.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        const {
+          proof,
+          publicInputs,
+          senderBalancePCT: userBalancePCT,
+        } = await privateBurn(
+          user,
+          userDecryptedBalance,
+          burnAmount,
+          userEncryptedBalance,
+          auditorPublicKey
+        );
+
+        await encryptedERC
+          .connect(user.signer)
+          .privateBurn(proof, publicInputs, userBalancePCT);
+
+        validParams = { proof, publicInputs, userBalancePCT };
+      });
+
+      it("should revert if proved balance is not valid", async () => {
+        const user = users[0];
+
+        await expect(
+          encryptedERC
+            .connect(user.signer)
+            .privateBurn(
+              validParams.proof,
+              validParams.publicInputs,
+              validParams.userBalancePCT
+            )
+        ).to.be.reverted;
+      });
+
+      it("users balance pct and elgamal ciphertext should be updated properly", async () => {
+        const user = users[0];
+        const balance = await encryptedERC.balanceOfStandalone(
+          user.signer.address
+        );
+
+        const totalBalance = await getDecryptedBalance(
+          user.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        userBalance = totalBalance;
+      });
+
+      it("should revert if user is not registered", async () => {
+        const nonRegisteredUser = users[5];
+
+        await expect(
+          encryptedERC
+            .connect(nonRegisteredUser.signer)
+            .privateBurn(
+              validParams.proof,
+              validParams.publicInputs,
+              validParams.userBalancePCT
+            )
+        ).to.be.reverted;
+      });
+
+      it("user public key and public key from proof should match, if not revert", async () => {
+        const notUser0 = users[4];
+
+        await expect(
+          encryptedERC
+            .connect(notUser0.signer)
+            .privateBurn(
+              validParams.proof,
+              validParams.publicInputs,
+              validParams.userBalancePCT
+            )
+        ).to.be.reverted;
+      });
+
+      it("auditor public key and auditor from proof should match, if not revert", async () => {
+        const user = users[0];
+
+        const _proof = validParams.proof;
+        const _publicInputs = [...validParams.publicInputs];
+
+        // auditor public key indexes are 23 and 24
+        // only change [23]
+        _publicInputs[23] = "100";
+        _publicInputs[24] = validParams.publicInputs[24];
+
+        await expect(
+          encryptedERC
+            .connect(user.signer)
+            .privateBurn(_proof, _publicInputs, validParams.userBalancePCT)
+        ).to.be.reverted;
+
+        // only change [24]
+        _publicInputs[23] = validParams.publicInputs[23];
+        _publicInputs[24] = "100";
+
+        await expect(
+          encryptedERC
+            .connect(user.signer)
+            .privateBurn(_proof, _publicInputs, validParams.userBalancePCT)
+        ).to.be.reverted;
+      });
+    });
+
+    // In order to test front running protection what we can do is to
+    // 0. owner mints some tokens to userA
+    // 1. userA creates a burn proof but do not send it to the contract
+    // 2. owner mints some tokens to userA repeatedly so userA's amount PCTs are updated
+    // 3. userA sends his burn proof
+    // after step 3, burn proof should be valid and need to updated pcts accordingly
+    describe("Front Running Protection", () => {
+      const INITIAL_MINT_COUNT = 4;
+      const SECOND_MINT_COUNT = 5;
+      const PER_MINT = 100n;
+      const EXPECTED_BALANCE_AFTER_INITIAL_MINT = 1000n;
+      const EXPECTED_BALANCE_AFTER_MINT = 2500n;
+
+      const burnAmount = 100n;
+      let userABalance = 0n;
+
+      let burnProof: {
+        proof: string[];
+        publicInputs: string[];
+        senderBalancePCT: string[];
+      };
+
+      it("0. owner mints some tokens to userA", async () => {
+        console.log("UserA Initial Balance", userABalance);
+
+        const userA = users[1];
+
+        for (let i = 0; i < INITIAL_MINT_COUNT; i++) {
+          const receiverPublicKey = userA.publicKey;
+          const mintAmount = PER_MINT * BigInt(i + 1);
+          const { proof, publicInputs } = await privateMint(
+            mintAmount,
+            receiverPublicKey,
+            auditorPublicKey
+          );
+
+          await encryptedERC
+            .connect(owner)
+            .privateMint(userA.signer.address, proof, publicInputs);
+        }
+      });
+
+      it("userA balance should be updated properly", async () => {
+        const userA = users[1];
+
+        const balance = await encryptedERC.balanceOfStandalone(
+          userA.signer.address
+        );
+
+        const totalBalance = await getDecryptedBalance(
+          userA.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        const amountPCTs = balance.amountPCTs;
+
+        const decryptedAmountPCTs = [];
+        for (const [pct] of amountPCTs) {
+          const decrypted = await decryptPCT(userA.privateKey, pct);
+          decryptedAmountPCTs.push(decrypted[0]);
+        }
+
+        expect(totalBalance).to.deep.equal(EXPECTED_BALANCE_AFTER_INITIAL_MINT);
+        userABalance = totalBalance;
+
+        console.log(
+          "UserA Balance After Initial Mint",
+          userABalance,
+          "has",
+          amountPCTs.length,
+          `amount pcts in contract before generating burn proof and has ${decryptedAmountPCTs.length} different amount pcts that have`,
+          decryptedAmountPCTs
+        );
+      });
+
+      it("1. userA creates a burn proof but do not send it to the contract", async () => {
+        const userA = users[1];
+        const balance = await encryptedERC.balanceOfStandalone(
+          userA.signer.address
+        );
+
+        const userEncryptedBalance = [...balance.eGCT.c1, ...balance.eGCT.c2];
+
+        const { proof, publicInputs, senderBalancePCT } = await privateBurn(
+          userA,
+          userABalance,
+          burnAmount,
+          userEncryptedBalance,
+          auditorPublicKey
+        );
+
+        burnProof = { proof, publicInputs, senderBalancePCT };
+      });
+
+      it("2. owner mints some tokens to userA repeatedly so userA's amount PCTs are updated", async () => {
+        const userA = users[1];
+
+        for (let i = 0; i < SECOND_MINT_COUNT; i++) {
+          const receiverPublicKey = userA.publicKey;
+
+          const { proof, publicInputs } = await privateMint(
+            PER_MINT * BigInt(i + 1),
+            receiverPublicKey,
+            auditorPublicKey
+          );
+
+          await encryptedERC
+            .connect(owner)
+            .privateMint(userA.signer.address, proof, publicInputs);
+        }
+      });
+
+      it("userA balance should be updated properly", async () => {
+        const userA = users[1];
+
+        const balance = await encryptedERC.balanceOfStandalone(
+          userA.signer.address
+        );
+
+        const totalBalance = await getDecryptedBalance(
+          userA.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        const amountPCTs = balance.amountPCTs;
+
+        const decryptedAmountPCTs = [];
+        for (const [pct] of amountPCTs) {
+          const decrypted = await decryptPCT(userA.privateKey, pct);
+          decryptedAmountPCTs.push(decrypted[0]);
+        }
+
+        expect(totalBalance).to.deep.equal(EXPECTED_BALANCE_AFTER_MINT);
+        userABalance = totalBalance;
+
+        console.log(
+          "UserA Balance After Second Mint",
+          userABalance,
+          "has",
+          amountPCTs.length,
+          "amount pcts in contract and has",
+          decryptedAmountPCTs
+        );
+      });
+
+      it("3. userA sends his burn proof", async () => {
+        const userA = users[1];
+
+        await encryptedERC
+          .connect(userA.signer)
+          .privateBurn(
+            burnProof.proof,
+            burnProof.publicInputs,
+            burnProof.senderBalancePCT
+          );
+
+        console.log("userA balance before burn", userABalance);
+        userABalance = userABalance - burnAmount;
+        console.log("userA balance after burn", userABalance);
+      });
+
+      it("after that amount pcts should be updated properly", async () => {
+        const userA = users[1];
+
+        const balance = await encryptedERC.balanceOfStandalone(
+          userA.signer.address
+        );
+
+        const totalBalance = await getDecryptedBalance(
+          userA.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        const decryptedBalancePCT = await decryptPCT(
+          userA.privateKey,
+          balance.balancePCT
+        );
+
+        const amountPCTs = balance.amountPCTs;
+        const decryptedAmountPCTs = [];
+        for (const [pct] of amountPCTs) {
+          const decrypted = await decryptPCT(userA.privateKey, pct);
+          decryptedAmountPCTs.push(decrypted[0]);
+        }
+
+        console.log("decryptedAmountPCTs", decryptedAmountPCTs);
+
+        expect(totalBalance).to.deep.equal(userABalance);
+        userABalance = totalBalance;
+
+        console.log(
+          "UserA Balance After Burn",
+          userABalance,
+          "has",
+          amountPCTs.length,
+          "amount pcts in contract and has",
+          decryptedAmountPCTs,
+          "and balance pct is",
+          decryptedBalancePCT[0]
+        );
+      });
+
+      it("userA can burn again", async () => {
+        const userA = users[1];
+        const balance = await encryptedERC.balanceOfStandalone(
+          userA.signer.address
+        );
+
+        const userEncryptedBalance = [...balance.eGCT.c1, ...balance.eGCT.c2];
+
+        const { proof, publicInputs, senderBalancePCT } = await privateBurn(
+          userA,
+          userABalance,
+          burnAmount,
+          userEncryptedBalance,
+          auditorPublicKey
+        );
+
+        await encryptedERC
+          .connect(userA.signer)
+          .privateBurn(proof, publicInputs, senderBalancePCT);
+
+        console.log("userA balance before burn", userABalance);
+        userABalance = userABalance - burnAmount;
+        console.log("userA balance after burn", userABalance);
+      });
+
+      it("after that amount pcts should be updated properly", async () => {
+        const userA = users[1];
+
+        const balance = await encryptedERC.balanceOfStandalone(
+          userA.signer.address
+        );
+
+        const totalBalance = await getDecryptedBalance(
+          userA.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        const decryptedBalancePCT = await decryptPCT(
+          userA.privateKey,
+          balance.balancePCT
+        );
+
+        const amountPCTs = balance.amountPCTs;
+        const decryptedAmountPCTs = [];
+        for (const [pct] of amountPCTs) {
+          const decrypted = await decryptPCT(userA.privateKey, pct);
+          decryptedAmountPCTs.push(decrypted[0]);
+        }
+
+        expect(totalBalance).to.deep.equal(userABalance);
+        userABalance = totalBalance;
+
+        console.log(
+          "UserA Balance After Burn",
+          userABalance,
+          "has",
+          amountPCTs.length,
+          "amount pcts in contract and has",
+          decryptedAmountPCTs,
+          "and balance pct is",
+          decryptedBalancePCT[0]
+        );
+      });
+
+      it("userA can burn again", async () => {
+        const userA = users[1];
+        const balance = await encryptedERC.balanceOfStandalone(
+          userA.signer.address
+        );
+
+        const userEncryptedBalance = [...balance.eGCT.c1, ...balance.eGCT.c2];
+
+        const { proof, publicInputs, senderBalancePCT } = await privateBurn(
+          userA,
+          userABalance,
+          burnAmount,
+          userEncryptedBalance,
+          auditorPublicKey
+        );
+
+        await encryptedERC
+          .connect(userA.signer)
+          .privateBurn(proof, publicInputs, senderBalancePCT);
+
+        console.log("userA balance before burn", userABalance);
+        userABalance = userABalance - burnAmount;
+        console.log("userA balance after burn", userABalance);
+      });
+
+      it("after that amount pcts should be updated properly", async () => {
+        const userA = users[1];
+
+        const balance = await encryptedERC.balanceOfStandalone(
+          userA.signer.address
+        );
+
+        const totalBalance = await getDecryptedBalance(
+          userA.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        const decryptedBalancePCT = await decryptPCT(
+          userA.privateKey,
+          balance.balancePCT
+        );
+
+        const amountPCTs = balance.amountPCTs;
+        const decryptedAmountPCTs = [];
+        for (const [pct] of amountPCTs) {
+          const decrypted = await decryptPCT(userA.privateKey, pct);
+          decryptedAmountPCTs.push(decrypted[0]);
+        }
+
+        expect(totalBalance).to.deep.equal(userABalance);
+        userABalance = totalBalance;
+
+        console.log(
+          "UserA Balance After Burn",
+          userABalance,
+          "has",
+          amountPCTs.length,
+          "amount pcts in contract and has",
+          decryptedAmountPCTs,
+          "and balance pct is",
+          decryptedBalancePCT[0]
+        );
+      });
+    });
+
+    describe("Private Transfer", () => {
+      let senderBalance = 0n;
+      const transferAmount = 500n;
+      let validParams: {
+        to: string;
+        proof: string[];
+        publicInputs: string[];
+        senderBalancePCT: string[];
+      };
+
+      it("sender needs to calculate the encrypted balance", async () => {
+        const sender = users[0];
+
+        const balance = await encryptedERC.balanceOfStandalone(
+          sender.signer.address
+        );
+
+        const totalBalance = await getDecryptedBalance(
+          sender.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        const decryptedBalance = decryptPoint(
+          sender.privateKey,
+          balance.eGCT.c1,
+          balance.eGCT.c2
+        );
+
+        const expectedPoint = mulPointEscalar(Base8, totalBalance);
+        expect(decryptedBalance).to.deep.equal(expectedPoint);
+
+        senderBalance = totalBalance;
+        console.log("Before transfer sender balance is", senderBalance);
+        console.log("Before transfer receiver balance is", 0n);
+      });
+
+      it("should transfer properly", async () => {
+        const sender = users[0];
+        const receiver = users[4];
+
+        const senderEncryptedBalance = await encryptedERC.balanceOfStandalone(
+          sender.signer.address
+        );
+
+        const { proof, publicInputs, senderBalancePCT } = await privateTransfer(
+          sender,
+          senderBalance,
+          receiver.publicKey,
+          transferAmount,
+          [
+            ...senderEncryptedBalance.eGCT.c1,
+            ...senderEncryptedBalance.eGCT.c2,
+          ],
+          auditorPublicKey
+        );
+
+        expect(
+          await encryptedERC
+            .connect(sender.signer)
+            .transfer(
+              receiver.signer.address,
+              0n,
+              proof,
+              publicInputs,
+              senderBalancePCT
+            )
+        ).to.be.not.reverted;
+
+        validParams = {
+          proof,
+          publicInputs,
+          senderBalancePCT,
+          to: receiver.signer.address,
+        };
+
+        console.log("Sender transfers", transferAmount, "to receiver");
+      });
+
+      it("should revert if sender provided balance is not valid", async () => {
+        const user = users[0];
+
+        await expect(
+          encryptedERC
+            .connect(user.signer)
+            .transfer(
+              validParams.to,
+              0n,
+              validParams.proof,
+              validParams.publicInputs,
+              validParams.senderBalancePCT
+            )
+        ).to.be.reverted;
+      });
+
+      it("sender balance should be updated properly", async () => {
+        const senderExpectedNewBalance = senderBalance - transferAmount;
+        const sender = users[0];
+
+        const balance = await encryptedERC.balanceOfStandalone(
+          sender.signer.address
+        );
+
+        const totalBalance = await getDecryptedBalance(
+          sender.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        const decryptedBalance = decryptPoint(
+          sender.privateKey,
+          balance.eGCT.c1,
+          balance.eGCT.c2
+        );
+
+        expect(totalBalance).to.equal(senderExpectedNewBalance);
+        const expectedPoint = mulPointEscalar(Base8, totalBalance);
+        expect(decryptedBalance).to.deep.equal(expectedPoint);
+
+        console.log("After transfer sender balance is", senderBalance);
+      });
+
+      it("receiver balance should be updated properly", async () => {
+        const receiver = users[4];
+
+        const balance = await encryptedERC.balanceOfStandalone(
+          receiver.signer.address
+        );
+
+        const totalBalance = await getDecryptedBalance(
+          receiver.privateKey,
+          balance.amountPCTs,
+          balance.balancePCT,
+          balance.eGCT
+        );
+
+        const decryptedBalance = decryptPoint(
+          receiver.privateKey,
+          balance.eGCT.c1,
+          balance.eGCT.c2
+        );
+
+        expect(totalBalance).to.equal(transferAmount); // ?
+        const expectedPoint = mulPointEscalar(Base8, totalBalance);
+        expect(decryptedBalance).to.deep.equal(expectedPoint);
+
+        console.log("After transfer receiver balance is", totalBalance);
+      });
+
+      it("should revert is 'to' is not registered", async () => {
+        const nonRegisteredUser = users[5];
+
+        await expect(
+          encryptedERC
+            .connect(users[0].signer)
+            .transfer(
+              nonRegisteredUser.signer.address,
+              0n,
+              validParams.proof,
+              validParams.publicInputs,
+              validParams.senderBalancePCT
+            )
+        ).to.be.reverted;
+      });
+
+      it("should revert is 'from' is not registered", async () => {
+        const nonRegisteredUser = users[5];
+
+        await expect(
+          encryptedERC
+            .connect(nonRegisteredUser.signer)
+            .transfer(
+              users[0].signer.address,
+              0n,
+              validParams.proof,
+              validParams.publicInputs,
+              validParams.senderBalancePCT
+            )
+        ).to.be.reverted;
+      });
+
+      it("should revert if sender public key and public key from proof do not match ", async () => {
+        // fromPublicKey is at index 0 and 1
+        // only change [0]
+        const _proof = validParams.proof;
+        const _publicInputs = [...validParams.publicInputs];
+
+        _publicInputs[0] = "100";
+        _publicInputs[1] = validParams.publicInputs[1];
+
+        await expect(
+          encryptedERC
+            .connect(users[0].signer)
+            .transfer(
+              validParams.to,
+              0n,
+              _proof,
+              _publicInputs,
+              validParams.senderBalancePCT
+            )
+        ).to.be.reverted;
+
+        // change [1]
+        _publicInputs[0] = validParams.publicInputs[0];
+        _publicInputs[1] = "100";
+
+        await expect(
+          encryptedERC
+            .connect(users[0].signer)
+            .transfer(
+              validParams.to,
+              0n,
+              _proof,
+              _publicInputs,
+              validParams.senderBalancePCT
+            )
+        ).to.be.reverted;
+      });
+
+      it("should revert if receiver public key and public key from proof do not match", async () => {
+        // toPublicKey is at index 10 and 11
+        // only change [10]
+        const _proof = validParams.proof;
+        const _publicInputs = [...validParams.publicInputs];
+
+        _publicInputs[10] = "100";
+        _publicInputs[11] = validParams.publicInputs[11];
+
+        await expect(
+          encryptedERC
+            .connect(users[0].signer)
+            .transfer(
+              validParams.to,
+              0n,
+              _proof,
+              _publicInputs,
+              validParams.senderBalancePCT
+            )
+        ).to.be.reverted;
+
+        // only change [11]
+        _publicInputs[10] = validParams.publicInputs[10];
+        _publicInputs[11] = "100";
+
+        await expect(
+          encryptedERC
+            .connect(users[0].signer)
+            .transfer(
+              validParams.to,
+              0n,
+              _proof,
+              _publicInputs,
+              validParams.senderBalancePCT
+            )
+        ).to.be.reverted;
+      });
+
+      it("should revert if auditor public key is not match with public key in proof", async () => {
+        const receiver = users[0];
+
+        const _proof = validParams.proof;
+        const _publicInputs = [...validParams.publicInputs];
+
+        // auditor public key indexes are 23 and 24
+        // only change [23]
+        _publicInputs[23] = "100";
+        _publicInputs[24] = validParams.publicInputs[24];
+
+        await expect(
+          encryptedERC
+            .connect(owner)
+            .transfer(
+              validParams.to,
+              0n,
+              _proof,
+              _publicInputs,
+              validParams.senderBalancePCT
+            )
+        ).to.be.reverted;
+
+        // only change [24]
+        _publicInputs[23] = validParams.publicInputs[23];
+        _publicInputs[24] = "100";
+
+        await expect(
+          encryptedERC
+            .connect(owner)
+            .transfer(
+              validParams.to,
+              0n,
+              _proof,
+              _publicInputs,
+              validParams.senderBalancePCT
+            )
+        ).to.be.reverted;
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Description
PATH: contracts/EncryptedERC.sol#L541-L543


The withdraw function in EncryptedERC contract accepts _amount, _tokenId, proof, input, _balancePCT parameters.

Inside the function there is a check:



{
    // _amount should match with the amount in the proof
    if (_amount != input[15]) {
        revert InvalidProof();
    }
}
As the _amount and input[15] parameters are given by the user, the check is redundant, as the user can give only one of them.

### Remediation
Remove the _amount parameter and the if condition, and take the amount value from the proof, also fix in the EERC SDK’s withdraw call.