### PR TITLE
test(history): add pending PCT withdrawal gas coverage

### DIFF
--- a/contracts/mocks/EncryptedERCHarness.sol
+++ b/contracts/mocks/EncryptedERCHarness.sol
@@ -1,0 +1,31 @@
+// (c) 2026, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+// SPDX-License-Identifier: Ecosystem
+
+pragma solidity 0.8.27;
+
+import {EncryptedERC} from "../EncryptedERC.sol";
+import {AmountPCT, CreateEncryptedERCParams, EncryptedBalance} from "../types/Types.sol";
+
+/**
+ * @dev Test-only EncryptedERC variant that can construct a worst-case pending history.
+ */
+contract EncryptedERCHarness is EncryptedERC {
+    constructor(CreateEncryptedERCParams memory params) EncryptedERC(params) {}
+
+    function seedPendingHistory(
+        address user,
+        uint256 tokenId,
+        uint256[7] calldata pct,
+        uint256 count,
+        uint256 checkpointIndex
+    ) external {
+        EncryptedBalance storage balance = balances[user][tokenId];
+        for (uint256 i = 0; i < count; i++) {
+            balance.amountPCTs.push(
+                AmountPCT({pct: pct, index: checkpointIndex})
+            );
+        }
+    }
+}

--- a/contracts/mocks/EncryptedUserBalancesHarness.sol
+++ b/contracts/mocks/EncryptedUserBalancesHarness.sol
@@ -1,0 +1,57 @@
+// (c) 2026, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+// SPDX-License-Identifier: Ecosystem
+
+pragma solidity 0.8.27;
+
+import {EncryptedUserBalances} from "../EncryptedUserBalances.sol";
+import {AmountPCT, EncryptedBalance} from "../types/Types.sol";
+
+/**
+ * @dev Test-only harness for measuring the cost of pruning pending amount PCT history.
+ * It seeds fully non-zero entries so the benchmark reflects the expensive storage-clear path.
+ */
+contract EncryptedUserBalancesHarness is EncryptedUserBalances {
+    function seedHistory(
+        address user,
+        uint256 tokenId,
+        uint256 count
+    ) external {
+        EncryptedBalance storage balance = balances[user][tokenId];
+        uint256 startIndex = balance.amountPCTs.length;
+
+        for (uint256 i = 0; i < count; i++) {
+            uint256[7] memory pct;
+            for (uint256 j = 0; j < pct.length; j++) {
+                pct[j] = (startIndex + i) * pct.length + j + 1;
+            }
+            balance.amountPCTs.push(
+                AmountPCT({pct: pct, index: startIndex + i})
+            );
+        }
+
+        balance.transactionIndex = startIndex + count;
+    }
+
+    function appendHistory(address user, uint256 tokenId) external {
+        uint256[7] memory pct;
+        pct[0] = 1;
+        _addToUserHistory(user, tokenId, pct);
+    }
+
+    function pruneHistory(
+        address user,
+        uint256 tokenId,
+        uint256 transactionIndex
+    ) external {
+        _deleteUserHistory(user, tokenId, transactionIndex);
+    }
+
+    function pendingHistoryLength(
+        address user,
+        uint256 tokenId
+    ) external view returns (uint256) {
+        return balances[user][tokenId].amountPCTs.length;
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
 				"prettier": "^3.5.3",
 				"prettier-plugin-solidity": "^1.4.2",
 				"solhint": "^5.0.5",
-				"solidity-coverage": "^0.8.14"
+				"solidity-coverage": "^0.8.14",
+				"ts-node": "^10.9.2"
 			}
 		},
 		"node_modules/@adraffy/ens-normalize": {
@@ -241,8 +242,7 @@
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
 			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
 			"dev": true,
-			"optional": true,
-			"peer": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/trace-mapping": "0.3.9"
 			},
@@ -949,27 +949,24 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
 			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
 			"dev": true,
-			"optional": true,
-			"peer": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"dev": true,
-			"optional": true,
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.9",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
 			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
 			"dev": true,
-			"optional": true,
-			"peer": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1874,36 +1871,32 @@
 			}
 		},
 		"node_modules/@tsconfig/node10": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-			"integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.13.tgz",
+			"integrity": "sha512-gcLdvR9HO1ZJBypsOGqaP6TFEzb6vIta0KSTLt9NAQ6pXQO3cRgSVyCN6pzYqI9DlJgY71XKO0dpDhCf08b3pg==",
 			"dev": true,
-			"optional": true,
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@tsconfig/node12": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
 			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
 			"dev": true,
-			"optional": true,
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@tsconfig/node14": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
 			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
 			"dev": true,
-			"optional": true,
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@tsconfig/node16": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
 			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
 			"dev": true,
-			"optional": true,
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@typechain/ethers-v6": {
 			"version": "0.5.1",
@@ -2233,12 +2226,11 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+			"integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
 			"dev": true,
-			"optional": true,
-			"peer": true,
+			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2247,12 +2239,11 @@
 			}
 		},
 		"node_modules/acorn-walk": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-			"integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+			"version": "8.3.5",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+			"integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
 			"dev": true,
-			"optional": true,
-			"peer": true,
+			"license": "MIT",
 			"dependencies": {
 				"acorn": "^8.11.0"
 			},
@@ -2412,8 +2403,7 @@
 			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
 			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
 			"dev": true,
-			"optional": true,
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -3425,8 +3415,7 @@
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
 			"dev": true,
-			"optional": true,
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -5952,8 +5941,7 @@
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
 			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
 			"dev": true,
-			"optional": true,
-			"peer": true
+			"license": "ISC"
 		},
 		"node_modules/markdown-table": {
 			"version": "2.0.0",
@@ -8433,8 +8421,7 @@
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
 			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
 			"dev": true,
-			"optional": true,
-			"peer": true,
+			"license": "MIT",
 			"dependencies": {
 				"@cspotcode/source-map-support": "^0.8.0",
 				"@tsconfig/node10": "^1.0.7",
@@ -8474,12 +8461,11 @@
 			}
 		},
 		"node_modules/ts-node/node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+			"integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
 			"dev": true,
-			"optional": true,
-			"peer": true,
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
 			}
@@ -8791,8 +8777,7 @@
 			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
 			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
 			"dev": true,
-			"optional": true,
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/viem": {
 			"version": "2.29.3",
@@ -9223,8 +9208,7 @@
 			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
 			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
 			"dev": true,
-			"optional": true,
-			"peer": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 		"prettier": "^3.5.3",
 		"prettier-plugin-solidity": "^1.4.2",
 		"solhint": "^5.0.5",
-		"solidity-coverage": "^0.8.14"
+		"solidity-coverage": "^0.8.14",
+		"ts-node": "^10.9.2"
 	},
 	"scripts": {
 		"test": "mocha 'src/**/*.test.js'",

--- a/test/EncryptedERC-Converter.ts
+++ b/test/EncryptedERC-Converter.ts
@@ -302,7 +302,9 @@ describe("EncryptedERC - Converter", () => {
 				expect(balance).to.equal(mintAmount);
 			});
 
-			it("should deposit tokens to EncryptedERC and return the dust properly and mint the proper balance", async () => {
+			it("should deposit tokens to EncryptedERC and return the dust properly and mint the proper balance", async function () {
+				this.timeout(120_000);
+
 				const ownerUser = users[0];
 				const erc20 = erc20s[1];
 

--- a/test/EncryptedERC-HistoryGas.ts
+++ b/test/EncryptedERC-HistoryGas.ts
@@ -151,7 +151,7 @@ describe("EncryptedERC withdrawal at the pending-history cap", () => {
       ](tokenId, proof, userBalancePCT);
     const receipt = await tx.wait();
 
-    expect(receipt!.gasUsed).to.be.lessThan(C_CHAIN_BLOCK_GAS_LIMIT);
+    expect(receipt?.gasUsed).to.be.lessThan(C_CHAIN_BLOCK_GAS_LIMIT);
     expect(await token.balanceOf(victim.signer.address)).to.equal(
       tokenBalanceBefore + withdrawalAmount,
     );

--- a/test/EncryptedERC-HistoryGas.ts
+++ b/test/EncryptedERC-HistoryGas.ts
@@ -1,0 +1,164 @@
+import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { expect } from "chai";
+import { ethers, zkit } from "hardhat";
+import type { RegistrationCircuit } from "../generated-types/zkit";
+import { processPoseidonEncryption } from "../src";
+import type { EncryptedERCHarness } from "../typechain-types/contracts/mocks/EncryptedERCHarness";
+import type { Registrar } from "../typechain-types/contracts/Registrar";
+import type { SimpleERC20 } from "../typechain-types/contracts/tokens/SimpleERC20";
+import { Registrar__factory } from "../typechain-types/factories/contracts";
+import { EncryptedERCHarness__factory } from "../typechain-types/factories/contracts/mocks/EncryptedERCHarness__factory";
+import { SimpleERC20__factory } from "../typechain-types/factories/contracts/tokens";
+import { deployLibrary, deployVerifiers, withdraw } from "./helpers";
+import { User } from "./user";
+
+const EERC_DECIMALS = 10;
+const MAX_PENDING_AMOUNT_PCTS = 300n;
+const C_CHAIN_BLOCK_GAS_LIMIT = 15_000_000n;
+
+describe("EncryptedERC withdrawal at the pending-history cap", () => {
+  let owner: SignerWithAddress;
+  let victimSigner: SignerWithAddress;
+  let registrar: Registrar;
+  let encryptedERC: EncryptedERCHarness;
+  let token: SimpleERC20;
+  let victim: User;
+  let auditor: User;
+
+  before(async () => {
+    [owner, victimSigner] = await ethers.getSigners();
+    victim = new User(victimSigner);
+    auditor = new User(owner);
+
+    const {
+      registrationVerifier,
+      mintVerifier,
+      withdrawVerifier,
+      transferVerifier,
+      burnVerifier,
+    } = await deployVerifiers(owner, false);
+    const babyJubJub = await deployLibrary(owner);
+
+    registrar = await new Registrar__factory(owner).deploy(
+      registrationVerifier,
+    );
+    await registrar.waitForDeployment();
+
+    encryptedERC = await new EncryptedERCHarness__factory(
+      { "contracts/libraries/BabyJubJub.sol:BabyJubJub": babyJubJub },
+      owner,
+    ).deploy({
+      registrar: registrar.target,
+      isConverter: true,
+      name: "",
+      symbol: "",
+      decimals: EERC_DECIMALS,
+      mintVerifier,
+      withdrawVerifier,
+      transferVerifier,
+      burnVerifier,
+    });
+    await encryptedERC.waitForDeployment();
+
+    token = await new SimpleERC20__factory(owner).deploy(
+      "Test",
+      "TEST",
+      EERC_DECIMALS,
+    );
+    await token.waitForDeployment();
+
+    const registrationCircuit = (await zkit.getCircuit(
+      "RegistrationCircuit",
+    )) as unknown as RegistrationCircuit;
+    const chainId = (await ethers.provider.getNetwork()).chainId;
+
+    for (const user of [victim, auditor]) {
+      const proof = await registrationCircuit.generateProof({
+        SenderPrivateKey: user.formattedPrivateKey,
+        SenderPublicKey: user.publicKey,
+        SenderAddress: BigInt(user.signer.address),
+        ChainID: chainId,
+        RegistrationHash: user.genRegistrationHash(chainId),
+      });
+      const calldata = await registrationCircuit.generateCalldata(proof);
+      await registrar.connect(user.signer).register(calldata);
+    }
+
+    await encryptedERC.connect(owner).setAuditorPublicKey(owner.address);
+  });
+
+  it("withdraws and clears 300 pending entries within the C-Chain block gas limit", async function () {
+    this.timeout(12000_000);
+    const depositAmount = 10_000n;
+    const withdrawalAmount = 1n;
+    const { ciphertext, nonce, authKey } = processPoseidonEncryption(
+      [depositAmount],
+      victim.publicKey,
+    );
+
+    await token.connect(owner).mint(victim.signer.address, depositAmount);
+    await token
+      .connect(victim.signer)
+      .approve(encryptedERC.target, depositAmount);
+    await encryptedERC
+      .connect(victim.signer)
+      [
+        "deposit(uint256,address,uint256[7])"
+      ](depositAmount, token.target, [...ciphertext, ...authKey, nonce]);
+
+    const tokenId = await encryptedERC.tokenIds(token.target);
+    const zeroValuePCT = processPoseidonEncryption([0n], victim.publicKey);
+    for (let seeded = 1n; seeded < MAX_PENDING_AMOUNT_PCTS; seeded += 50n) {
+      const count =
+        MAX_PENDING_AMOUNT_PCTS - seeded < 50n
+          ? MAX_PENDING_AMOUNT_PCTS - seeded
+          : 50n;
+
+        
+
+      const tx = await encryptedERC.seedPendingHistory(
+        victim.signer.address,
+        tokenId,
+        [
+          ...zeroValuePCT.ciphertext,
+          ...zeroValuePCT.authKey,
+          zeroValuePCT.nonce,
+        ],
+        count,
+        0,
+      );
+      await tx.wait();
+    }
+
+    const balance = await encryptedERC.balanceOf(
+      victim.signer.address,
+      tokenId,
+    );
+    expect(balance.amountPCTs).to.have.length(Number(MAX_PENDING_AMOUNT_PCTS));
+
+    const { proof, userBalancePCT } = await withdraw(
+      withdrawalAmount,
+      victim,
+      [...balance.eGCT.c1, ...balance.eGCT.c2],
+      depositAmount,
+      await encryptedERC.auditorPublicKey(),
+    );
+    const tokenBalanceBefore = await token.balanceOf(victim.signer.address);
+    const tx = await encryptedERC
+      .connect(victim.signer)
+      [
+        "withdraw(uint256,((uint256[2],uint256[2][2],uint256[2]),uint256[16]),uint256[7])"
+      ](tokenId, proof, userBalancePCT);
+    const receipt = await tx.wait();
+
+    expect(receipt!.gasUsed).to.be.lessThan(C_CHAIN_BLOCK_GAS_LIMIT);
+    expect(await token.balanceOf(victim.signer.address)).to.equal(
+      tokenBalanceBefore + withdrawalAmount,
+    );
+    const balanceAfter = await encryptedERC.balanceOf(
+      victim.signer.address,
+      tokenId,
+    );
+    expect(balanceAfter.amountPCTs).to.be.empty;
+  });
+});

--- a/test/EncryptedUserBalances.ts
+++ b/test/EncryptedUserBalances.ts
@@ -48,7 +48,7 @@ describe("EncryptedUserBalances pending history", () => {
     // Avalanche C-Chain's documented block gas limit reference is 15M. This is
     // intentionally only a benchmark guard: a full transfer/withdrawal must be
     // measured separately because it also includes proof verification and payout work.
-    expect(receipt!.gasUsed).to.be.lessThan(12_000_000n);
+    expect(receipt?.gasUsed).to.be.lessThan(12_000_000n);
     expect(
       await harness.pendingHistoryLength(victim.address, tokenId),
     ).to.equal(0n);

--- a/test/EncryptedUserBalances.ts
+++ b/test/EncryptedUserBalances.ts
@@ -1,0 +1,56 @@
+import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import type { EncryptedUserBalancesHarness } from "../typechain-types/contracts/mocks/EncryptedUserBalancesHarness";
+import { EncryptedUserBalancesHarness__factory } from "../typechain-types/factories/contracts/mocks/EncryptedUserBalancesHarness__factory";
+
+describe("EncryptedUserBalances pending history", () => {
+  let harness: EncryptedUserBalancesHarness;
+  let owner: SignerWithAddress;
+  let victim: SignerWithAddress;
+
+  const seedHistory = async (tokenId: bigint, count: bigint) => {
+    const batchSize = 50n;
+    for (let seeded = 0n; seeded < count; seeded += batchSize) {
+      const batch = count - seeded < batchSize ? count - seeded : batchSize;
+      await harness.seedHistory(victim.address, tokenId, batch);
+    }
+  };
+
+  before(async () => {
+    [owner, victim] = await ethers.getSigners();
+    const factory = new EncryptedUserBalancesHarness__factory(owner);
+    harness = await factory.deploy();
+    await harness.waitForDeployment();
+  });
+
+  it("rejects a credit once the pending-history cap is reached", async () => {
+    const maxPendingAmountPCTs = await harness.MAX_PENDING_AMOUNT_PCTS();
+    await seedHistory(0n, maxPendingAmountPCTs - 1n);
+    await expect(harness.appendHistory(victim.address, 0)).to.not.be.reverted;
+    await expect(
+      harness.appendHistory(victim.address, 0),
+    ).to.be.revertedWithCustomError(harness, "PendingHistoryLimitReached");
+  });
+
+  it("prunes a worst-case full history within the configured gas budget", async () => {
+    const tokenId = 1;
+    const maxPendingAmountPCTs = await harness.MAX_PENDING_AMOUNT_PCTS();
+    await seedHistory(BigInt(tokenId), maxPendingAmountPCTs);
+
+    const tx = await harness.pruneHistory(
+      victim.address,
+      tokenId,
+      maxPendingAmountPCTs - 1n,
+    );
+    const receipt = await tx.wait();
+
+    // Avalanche C-Chain's documented block gas limit reference is 15M. This is
+    // intentionally only a benchmark guard: a full transfer/withdrawal must be
+    // measured separately because it also includes proof verification and payout work.
+    expect(receipt!.gasUsed).to.be.lessThan(12_000_000n);
+    expect(
+      await harness.pendingHistoryLength(victim.address, tokenId),
+    ).to.equal(0n);
+  });
+});


### PR DESCRIPTION
## What

- Add test-only harnesses for constructing pending PCT history.
- Add boundary coverage for the pending-history cap and worst-case pruning.
- Add an end-to-end converter withdrawal benchmark at 300 pending entries.
- Extend the existing multi-deposit test timeout for its crypto-heavy workload.

## Why

- Verify that the pending-history cap preserves a user’s ability to exit.
- Prevent regressions where a full pending-history queue blocks withdrawal or transfer through gas exhaustion.

## How

- `EncryptedUserBalancesHarness` seeds fully nonzero entries and measures bounded pruning.
- `EncryptedERCHarness` seeds a valid 300-entry history, then exercises the real deposit, proof generation, withdrawal, ERC-20 payout, and cleanup path.
- The full withdrawal test asserts that gas remains below the 15M C-Chain block-gas limit.

## Verification

- Tests run: `REPORT_GAS=true npx hardhat test test/EncryptedERC-HistoryGas.ts`
- Tests run: `npx tsc --noEmit`
- Manual checks: confirmed the 300-entry withdrawal succeeds, clears history, and transfers the expected ERC-20 amount.

## Risk & rollout

- Risk level: Low
- Rollout plan: Test-only contracts and tests; no production contract behavior changes.
- Backout plan: Revert the test-only harnesses and test changes.

## Alternatives / follow-ups

- The full benchmark currently takes about 21 minutes because it writes 299 complete storage entries. Move it to nightly CI or replace setup with direct Hardhat storage injection.

## Notes for reviewers

- Confirm the seeded PCT entries model the expensive storage-cleanup path.
- Review the 15M gas threshold against the intended deployment chain.
- Confirm the end-to-end test uses the real withdrawal verifier and payout flow.
- Check that test-only harnesses remain under `contracts/mocks` and are never deployed by release scripts.
- Consider whether the benchmark belongs in the standard CI suite or nightly coverage.